### PR TITLE
Update: Expanded clone API (fixes #17)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -151,58 +151,82 @@ class ContentModule extends AbstractApiModule {
     return descendants
   }
 
-  /**
-   * Creates a new parent content type, along with any necessary children
-   * @param {external:ExpressRequest} req
-   */
-  async insertRecursive (req) {
-    const rootId = req.apiData.query.rootId
-    const createdBy = req.auth.user._id.toString()
-    let childTypes = ['course', 'page', 'article', 'block', 'component']
-    const defaultData = {
-      page: { title: req.translate('app.newpagetitle') },
-      article: { title: req.translate('app.newarticletitle') },
-      block: { title: req.translate('app.newblocktitle') },
-      component: {
-        _component: 'adapt-contrib-text',
-        _layout: 'full',
-        title: req.translate('app.newtextcomponenttitle'),
-        body: req.translate('app.newtextcomponentbody')
-      }
+  async descendToType (node, type) {
+    console.log('descendToType at', node._type, 'towards', type)
+    const [lastChild] = (await this.find({ _parentId: node._id })).slice(-1)
+    if (!lastChild) return node
+    if (lastChild._type === type) return lastChild
+    return await this.descendToType(lastChild, type)
+  }
+
+  async ascendToType (node, type) {
+    console.log('ascendToType at', node._type, 'towards', type)
+    const [parent] = (await this.find({ _id: node._parentId })).slice(-1)
+    if (!parent) throw this.app.errors.INVALID_PARENT.setData({ parentId: node._parentId })
+    if (parent._type === type) return parent
+    return await this.ascendToType(parent, type)
+  }
+
+  async constructToType (node, type, userId, lang) {
+    console.log('constructToType from', node._type, 'to', type)
+    const typeHierarchy = ['course', 'page', 'article', 'block', 'component']
+    const filteredTypes = typeHierarchy.slice(typeHierarchy.indexOf(node._type) + 1, typeHierarchy.indexOf(type) + 1)
+    return await this.insertRecursive(node._id, userId.toString(), null, false, filteredTypes, lang)
+  }
+
+  async appendToBlock (block, component, userId, lang, isCut) {
+    const children = await this.find({ _parentId: block._id })
+
+    const leftChild = children.find(child => child._layout === 'left')
+    const rightChild = children.find(child => child._layout === 'right')
+
+    if (leftChild && !rightChild) {
+      component._layout = 'right'
+    } else if (!leftChild && rightChild) {
+      component._layout = 'left'
+    } else if (children.length > 0) {
+      [block] = await this.insertRecursive(block._parentId, userId.toString(), { _sortOrder: block._sortOrder + 1 }, false, ['block'], lang)
     }
-    const newItems = []
-    let parent
-    try {
-      // figure out which children need creating
-      if (rootId === undefined) { // new course
-        parent = await this.insert({ _type: 'course', createdBy, ...req.apiData.data }, { schemaName: 'course' })
-        newItems.push(parent)
-        childTypes.splice(0, 1, 'config')
-      } else {
-        parent = (await this.find({ _id: rootId }))[0]
-        // special case for menus
-        req.body?._type === 'menu'
-          ? childTypes.splice(0, 1, 'menu')
-          : childTypes = childTypes.slice(childTypes.indexOf(parent._type) + 1)
-      }
-      for (const _type of childTypes) {
-        const data = Object.assign({ _type, createdBy }, defaultData[_type])
-        if (parent) {
-          Object.assign(data, {
-            _parentId: parent._id.toString(),
-            _courseId: parent._courseId.toString()
-          })
-        }
-        const item = await this.insert(data)
-        newItems.push(item)
-        if (_type !== 'config') parent = item
-      }
-    } catch (e) {
-      await Promise.all(newItems.map(({ _id }) => super.delete({ _id }, { invokePostHook: false })))
-      throw e
+
+    if (isCut) return await this.cut(block, component)
+
+    return await this.append(block, component, isCut)
+  }
+
+  async append (parent, child, isCut) {
+    if (isCut) return await this.cut(parent, child, child._sortOrder)
+
+    child._courseId = parent?._type === 'course' ? parent?._id : parent?._courseId
+    child._parentId = parent._id
+
+    const schemaName = child._type === 'menu' || child._type === 'page' ? 'contentobject' : child._type
+
+    return await this.insert(AbstractApiUtils.stringifyValues(child), { schemaName })
+  }
+
+  async cut (parent, child, sortOrder) {
+    const courseId = parent?._type === 'course' ? parent?._id : parent?._courseId
+    const isMovingCourse = courseId.toString() !== child._courseId.toString()
+
+    const newData = await this.update({ _id: child._id }, {
+      _courseId: courseId.toString(),
+      _parentId: parent._id.toString(),
+      _sortOrder: sortOrder
+    })
+
+    const updateRecursive = async (parentId) => {
+      const children = await this.find({ _parentId: parentId })
+      return await Promise.all(children.map(async ({ title, _id, _courseId }) => {
+        console.log('moving', title, _id, 'from course', _courseId, 'to', courseId.toString())
+        await this.update({ _id }, { _courseId: courseId.toString() })
+        return await updateRecursive(_id)
+      }))
     }
-    // return the topmost new item
-    return newItems[0]
+
+    // update subtree of child if cutting from one course to another
+    if (isMovingCourse) updateRecursive(child._id)
+
+    return newData
   }
 
   /**
@@ -213,7 +237,7 @@ class ContentModule extends AbstractApiModule {
    * @param {Object} customData Data to be applied to the content item
    * @return {Promise}
    */
-  async clone (userId, _id, _parentId, customData = {}) {
+  async clone (userId, _id, _parentId, customData = {}, lang, isCut) {
     const [originalDoc] = await this.find({ _id })
     if (!originalDoc) {
       throw this.app.errors.NOT_FOUND
@@ -224,25 +248,176 @@ class ContentModule extends AbstractApiModule {
     if (!parent && originalDoc._type !== 'course' && originalDoc._type !== 'config') {
       throw this.app.errors.INVALID_PARENT.setData({ parentId: _parentId })
     }
-    const schemaName = originalDoc._type === 'menu' || originalDoc._type === 'page' ? 'contentobject' : originalDoc._type
-    // const newData = await this.insert(Object.assign(originalDoc, {
-    const newData = await this.insert(AbstractApiUtils.stringifyValues({
-      ...originalDoc,
-      _id: undefined,
-      _trackingId: undefined,
-      _courseId: parent?._type === 'course' ? parent?._id : parent?._courseId,
-      _parentId,
-      createdBy: userId,
-      ...customData
-    }), { schemaName })
+
+    let newData
+
+    if (parent) {
+      // clone menu, page, article, block, component
+      const typeHierarchy = ['course', 'menu', 'page', 'article', 'block', 'component']
+      const sourceType = originalDoc._type
+      const indexOfType = type => typeHierarchy.indexOf(type)
+      const indexOfSourceType = indexOfType(originalDoc._type)
+      const indexOfMenuType = indexOfType('menu')
+      const indexOfPageType = indexOfType('page')
+      const indexOfGivenTargetType = indexOfType(parent._type)
+      const requiredTargetType = typeHierarchy[indexOfSourceType - 1]
+      const isGivenTargetGrandparentType = indexOfGivenTargetType < indexOfSourceType - 1
+
+      const proposedData = {
+        ...originalDoc,
+        _trackingId: undefined,
+        createdBy: userId,
+        ...customData
+      }
+
+      if (!isCut) proposedData._id = undefined
+
+      const isSourceMenu = indexOfSourceType === indexOfMenuType
+      const isSourcePage = indexOfSourceType === indexOfPageType
+      const isGivenTargetMenu = indexOfGivenTargetType === indexOfMenuType
+      const isCloneMenuIntoMenu = isSourceMenu && isGivenTargetMenu
+      const isClonePageIntoAncestor = isSourcePage && indexOfGivenTargetType < indexOfPageType
+      const isCloneChildIntoParent = indexOfGivenTargetType === indexOfSourceType - 1
+
+      if (isCloneMenuIntoMenu || isClonePageIntoAncestor || isCloneChildIntoParent) {
+        // scenario 1: expected usage (paste component into block, block into article etc)
+        console.log('clone scenario 1', sourceType, 'into', parent._type)
+
+        newData = originalDoc._type === 'component'
+          ? await this.appendToBlock(parent, proposedData, userId, lang, isCut)
+          : await this.append(parent, proposedData, isCut)
+      } else if (isGivenTargetGrandparentType) {
+        // scenario 2: paste component directly into article/page or block directly into page
+        console.log('clone scenario 2', sourceType, 'into', parent._type)
+
+        let node
+
+        if (customData._sortOrder) {
+          // interpret _sortOrder as (i) new container is required and (ii) position of new container
+          delete proposedData._sortOrder;
+          // create the top level container with specified order
+          [node] = await this.insertRecursive(_parentId, userId.toString(), { _sortOrder: customData._sortOrder }, false, [typeHierarchy[indexOfGivenTargetType + 1]], lang)
+        } else {
+          // order not given so append as last descendant
+          node = await this.descendToType(parent, requiredTargetType)
+        }
+
+        if (node._type !== requiredTargetType) {
+          // construct remainder of subtree
+          [node] = (await this.constructToType(node, requiredTargetType, userId, lang)).slice(-1)
+          newData = await this.append(node, proposedData, isCut)
+        } else {
+          // complete subtree already exists
+          newData = originalDoc._type === 'component'
+            ? await this.appendToBlock(node, proposedData, userId, lang, isCut)
+            : await this.append(node, proposedData, isCut)
+        }
+      } else {
+        // scenario 3: paste component into component, block into component etc
+        console.log('clone scenario 3', sourceType, 'into', parent._type)
+
+        const ancestorOfSourceType = await this.ascendToType(parent, sourceType)
+        const node = await this.ascendToType(parent, requiredTargetType)
+
+        newData = originalDoc._type === 'component' ? await this.appendToBlock(node, proposedData, userId, lang, isCut) : await this.append(node, { ...proposedData, _sortOrder: ancestorOfSourceType._sortOrder + 1 }, isCut)
+      }
+    } else {
+      // clone course/config
+      const schemaName = originalDoc._type === 'menu' || originalDoc._type === 'page' ? 'contentobject' : originalDoc._type
+      // const newData = await this.insert(Object.assign(originalDoc, {
+      newData = await this.insert(AbstractApiUtils.stringifyValues({
+        ...originalDoc,
+        _id: undefined,
+        _trackingId: undefined,
+        _courseId: parent?._type === 'course' ? parent?._id : parent?._courseId,
+        _parentId,
+        createdBy: userId,
+        ...customData
+      }), { schemaName })
+    }
 
     if (originalDoc._type === 'course') {
       const [config] = await this.find({ _type: 'config', _courseId: originalDoc._courseId })
-      await this.clone(userId, config._id, undefined, { _courseId: newData._id.toString() })
+      await this.clone(userId, config._id, undefined, { _courseId: newData._id.toString() }, lang)
     }
-    const children = await this.find({ _parentId: _id })
-    await Promise.all(children.map(({ _id }) => this.clone(userId, _id, newData._id)))
+
+    // re-parent the source
+    if (isCut) return newData
+
+    // clone subtree of source
+    // ($ne condition ensures correct operation for cloning a menu into itself)
+    const children = await this.find({ _parentId: _id, _id: { $ne: newData._id } })
+    await Promise.all(children.map(({ _id }) => this.clone(userId, _id, newData._id, undefined, lang)))
     return newData
+  }
+
+  /**
+   * Creates a new parent content type, along with any necessary children
+   * @param {String} rootId ID of the root node into which the content hierarchy will be created
+   * @param {String} userId The user performing the action
+   * @param {Object} customData Data to be applied to the each item created
+   * @param {Boolean} isMenu Whether a menu is to be created
+   * @param {Array} childTypes The hierarchically ordered content types to be created
+   * @param lang The language into which to translate default content strings
+   * @return {Array} List of hierarchically ordered content models that were created
+   */
+  async insertRecursive (rootId, createdBy, customData, isMenu = false, childTypes, lang) {
+    const defaultData = {
+      page: { title: this.app.lang.translate(lang, 'app.newpagetitle') },
+      article: { title: this.app.lang.translate(lang, 'app.newarticletitle') },
+      block: { title: this.app.lang.translate(lang, 'app.newblocktitle') },
+      component: {
+        _component: 'adapt-contrib-text',
+        _layout: 'full',
+        title: this.app.lang.translate(lang, 'app.newtextcomponenttitle'),
+        body: this.app.lang.translate(lang, 'app.newtextcomponentbody')
+      }
+    }
+    const newItems = []
+
+    let parent
+    try {
+      // if no root assume a new course should be created
+      if (!rootId) {
+        console.log('insertRecursive course')
+        parent = await this.insert({ _type: 'course', createdBy, ...customData }, { schemaName: 'course' })
+        newItems.push(parent)
+        childTypes = ['config', 'page', 'article', 'block', 'component']
+      } else {
+        parent = (await this.find({ _id: rootId }))[0]
+        // if hierarchy isn't specified then infer what to create
+        if (!childTypes) {
+          childTypes = ['course', 'menu', 'page', 'article', 'block', 'component']
+          if (isMenu) {
+            // remove 'course' so that we will create ['menu', 'page'...]
+            childTypes.splice(0, 1)
+          } else {
+            // if inserting into course remove 'menu' so that we have ['course', 'page'...]
+            if (parent._type === 'course') childTypes.splice(1, 1)
+            // select the appropriate starting point in the hierarchy
+            childTypes = childTypes.slice(childTypes.indexOf(parent._type) + 1)
+          }
+        }
+      }
+      for (const _type of childTypes) {
+        const data = Object.assign({ _type, createdBy }, defaultData[_type], customData)
+        if (parent) {
+          Object.assign(data, {
+            _parentId: parent._id.toString(),
+            _courseId: parent._courseId.toString()
+          })
+        }
+        console.log('insertRecursive', _type)
+        const item = await this.insert(data)
+        newItems.push(item)
+        if (_type !== 'config') parent = item
+      }
+    } catch (e) {
+      await Promise.all(newItems.map(({ _id }) => super.delete({ _id }, { invokePostHook: false })))
+      throw e
+    }
+    // return the topmost new item
+    return newItems
   }
 
   /**
@@ -326,7 +501,10 @@ class ContentModule extends AbstractApiModule {
    */
   async handleInsertRecursive (req, res, next) {
     try {
-      res.status(201).json(await this.insertRecursive(req))
+      const rootId = req.apiData.query.rootId
+      const createdBy = req.auth.user._id.toString()
+      const isMenu = req.body?._type === 'menu'
+      res.status(201).json(await this.insertRecursive(rootId, createdBy, undefined, isMenu, undefined, req.acceptsLanguages(this.supportedLanguages)))
     } catch (e) {
       return next(e)
     }
@@ -342,13 +520,13 @@ class ContentModule extends AbstractApiModule {
   async handleClone (req, res, next) {
     try {
       await this.checkAccess(req, req.apiData.query)
-      const { _id, _parentId } = req.body
+      const { _id, _parentId, isCut } = req.body
 
       const customData = { ...req.body }
       delete customData._id
       delete customData._parentId
 
-      const newData = await this.clone(req.auth.user._id, _id, _parentId, customData)
+      const newData = await this.clone(req.auth.user._id, _id, _parentId, customData, req.acceptsLanguages(this.supportedLanguages), isCut)
       res.status(201).json(newData)
     } catch (e) {
       return next(e)


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

#17

### Update
* Facilitate new cut/copy/paste functionality
* Allow content to be copied arbitrarily (including from course to course)
* Handle paste requests intelligently, e.g:
  * request paste of component into page: ensure ancestor article and block exist
  * request paste of article into block: ascend hierarchy and paste into page

### New
* Cut - content can be moved from one location to another