### PR TITLE
Fix: add check for data._enabledPlugins in getSchema (fixes #45)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -84,7 +84,8 @@ class ContentModule extends AbstractApiModule {
     if (_courseId) {
       try {
         const [config] = await this.find({ _type: 'config', _courseId }, { validate: false })
-        enabledPluginSchemas = config._enabledPlugins.reduce((m, p) => [...m, ...contentplugin.getPluginSchemas(p)], [])
+        const pluginList = config?._enabledPlugins ?? data?._enabledPlugins ?? []
+        enabledPluginSchemas = pluginList.reduce((m, p) => [...m, ...contentplugin.getPluginSchemas(p)], [])
       } catch (e) {}
     }
     return jsonschema.getSchema(schemaName, {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)
When checking for _enabledPlugins it finds config, when getting schema for config on a cloned course there is no config so is returning an empty array for _enabledPlugins, added an additional check for data being passed through. 

[//]: # (Add a link to the original issue)
#45 

[//]: # (Delete as appropriate)
### Fix
* add check for data._enabledPlugins in getSchema (fixes #45)


