### PR TITLE
Fix: Await sort order update in updateSortOrder (fixes #89)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -275,7 +275,7 @@ class ContentModule extends AbstractApiModule {
     }
     return Promise.all(siblings.map(async (s, i) => {
       const _sortOrder = i + 1
-      if (s._sortOrder !== _sortOrder) super.update({ _id: s._id }, { _sortOrder })
+      if (s._sortOrder !== _sortOrder) return super.update({ _id: s._id }, { _sortOrder })
     }))
   }
 


### PR DESCRIPTION
### Fix
* Add missing `return` before `super.update()` in `updateSortOrder` so the promise is properly awaited by `Promise.all`, preventing a race condition where a subsequent delete can remove the document before the unawaited update completes

### Testing
1. Run integration tests — the `should delete by _friendlyId across language courses` test should now pass reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)