### PR TITLE
Fix: Enforce _friendlyId uniqueness per course

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -6,6 +6,14 @@
     "description": "Specified item is not a valid content item Invalid parent itemparent",
     "statusCode": 500
   },
+  "DUPL_FRIENDLY_ID": {
+    "data": {
+      "_friendlyId": "The duplicate friendly ID",
+      "_courseId": "The course ID"
+    },
+    "description": "A content item with this _friendlyId already exists in this course",
+    "statusCode": 409
+  },
   "UNKNOWN_SCHEMA_NAME": {
     "data": {
       "_id": "The database _id",

--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -50,6 +50,10 @@ class ContentModule extends AbstractApiModule {
     await this.registerConfigSchemas()
 
     await mongodb.setIndex(this.collectionName, { _courseId: 1, _parentId: 1, _type: 1 })
+    await mongodb.setIndex(this.collectionName, { _courseId: 1, _friendlyId: 1 }, {
+      unique: true,
+      partialFilterExpression: { _friendlyId: { $type: 'string' } }
+    })
   }
 
   /** @override */
@@ -109,7 +113,15 @@ class ContentModule extends AbstractApiModule {
 
   /** @override */
   async insert (data, options = {}, mongoOptions = {}) {
-    const doc = await super.insert(data, options, mongoOptions)
+    let doc
+    try {
+      doc = await super.insert(data, options, mongoOptions)
+    } catch (e) {
+      if (e.code === this.app.errors.MONGO_DUPL_INDEX?.code) {
+        throw this.app.errors.DUPL_FRIENDLY_ID.setData({ _friendlyId: data._friendlyId, _courseId: data._courseId })
+      }
+      throw e
+    }
 
     if (doc._type === 'course') { // add the _courseId to a new course to make querying easier
       return this.update({ _id: doc._id }, { _courseId: doc._id.toString() })
@@ -123,7 +135,15 @@ class ContentModule extends AbstractApiModule {
 
   /** @override */
   async update (query, data, options, mongoOptions) {
-    const doc = await super.update(query, data, options, mongoOptions)
+    let doc
+    try {
+      doc = await super.update(query, data, options, mongoOptions)
+    } catch (e) {
+      if (e.code === this.app.errors.MONGO_DUPL_INDEX?.code) {
+        throw this.app.errors.DUPL_FRIENDLY_ID.setData({ _friendlyId: data._friendlyId, _courseId: data._courseId })
+      }
+      throw e
+    }
     await Promise.all([
       this.updateSortOrder(doc, data),
       this.updateEnabledPlugins(doc, data._enabledPlugins ? { forceUpdate: true } : {})
@@ -232,6 +252,7 @@ class ContentModule extends AbstractApiModule {
       ...originalDoc,
       _id: undefined,
       _trackingId: undefined,
+      _friendlyId: originalDoc._type !== 'course' ? undefined : originalDoc._friendlyId,
       _courseId: parent?._type === 'course' ? parent?._id : parent?._courseId,
       _parentId,
       createdBy: userId,

--- a/tests/ContentModule.spec.js
+++ b/tests/ContentModule.spec.js
@@ -30,7 +30,9 @@ function createMockApp () {
     errors: {
       NOT_FOUND: createMockError('NOT_FOUND'),
       INVALID_PARENT: createMockError('INVALID_PARENT'),
-      UNKNOWN_SCHEMA_NAME: createMockError('UNKNOWN_SCHEMA_NAME')
+      UNKNOWN_SCHEMA_NAME: createMockError('UNKNOWN_SCHEMA_NAME'),
+      MONGO_DUPL_INDEX: createMockError('MONGO_DUPL_INDEX'),
+      DUPL_FRIENDLY_ID: createMockError('DUPL_FRIENDLY_ID')
     },
     waitForModule: mock.fn(async () => ({})),
     config: { get: mock.fn(() => 10) }
@@ -1686,6 +1688,141 @@ describe('ContentModule', () => {
   // Bug fixes
   // -----------------------------------------------------------------------
   describe('bug fixes', () => {
+    it('insert should catch MONGO_DUPL_INDEX and throw DUPL_FRIENDLY_ID', async () => {
+      const duplError = createMockError('MONGO_DUPL_INDEX')
+      const inst = createInstance()
+      const superInsert = mock.fn(async () => { throw duplError })
+
+      const origProto = Object.getPrototypeOf(ContentModule.prototype)
+      const origInsert = origProto.insert
+      origProto.insert = superInsert
+      try {
+        await assert.rejects(
+          () => ContentModule.prototype.insert.call(inst, { _friendlyId: 'fid-1', _courseId: 'c1', _type: 'article' }),
+          (err) => {
+            assert.equal(err.code, 'DUPL_FRIENDLY_ID')
+            assert.equal(err.data._friendlyId, 'fid-1')
+            assert.equal(err.data._courseId, 'c1')
+            return true
+          }
+        )
+      } finally {
+        origProto.insert = origInsert
+      }
+    })
+
+    it('insert should re-throw non-duplicate errors unchanged', async () => {
+      const otherError = new Error('SOME_OTHER_ERROR')
+      otherError.code = 'SOME_OTHER_ERROR'
+      const inst = createInstance()
+
+      const origProto = Object.getPrototypeOf(ContentModule.prototype)
+      const origInsert = origProto.insert
+      origProto.insert = mock.fn(async () => { throw otherError })
+      try {
+        await assert.rejects(
+          () => ContentModule.prototype.insert.call(inst, { _type: 'article' }),
+          (err) => {
+            assert.equal(err.code, 'SOME_OTHER_ERROR')
+            return true
+          }
+        )
+      } finally {
+        origProto.insert = origInsert
+      }
+    })
+
+    it('update should catch MONGO_DUPL_INDEX and throw DUPL_FRIENDLY_ID', async () => {
+      const duplError = createMockError('MONGO_DUPL_INDEX')
+      const inst = createInstance()
+
+      const origProto = Object.getPrototypeOf(ContentModule.prototype)
+      const origUpdate = origProto.update
+      origProto.update = mock.fn(async () => { throw duplError })
+      try {
+        await assert.rejects(
+          () => ContentModule.prototype.update.call(inst, { _id: 'x' }, { _friendlyId: 'fid-1', _courseId: 'c1' }),
+          (err) => {
+            assert.equal(err.code, 'DUPL_FRIENDLY_ID')
+            assert.equal(err.data._friendlyId, 'fid-1')
+            assert.equal(err.data._courseId, 'c1')
+            return true
+          }
+        )
+      } finally {
+        origProto.update = origUpdate
+      }
+    })
+
+    it('update should re-throw non-duplicate errors unchanged', async () => {
+      const otherError = new Error('SOME_OTHER_ERROR')
+      otherError.code = 'SOME_OTHER_ERROR'
+      const inst = createInstance()
+
+      const origProto = Object.getPrototypeOf(ContentModule.prototype)
+      const origUpdate = origProto.update
+      origProto.update = mock.fn(async () => { throw otherError })
+      try {
+        await assert.rejects(
+          () => ContentModule.prototype.update.call(inst, { _id: 'x' }, { title: 'Updated' }),
+          (err) => {
+            assert.equal(err.code, 'SOME_OTHER_ERROR')
+            return true
+          }
+        )
+      } finally {
+        origProto.update = origUpdate
+      }
+    })
+
+    it('clone should clear _friendlyId for non-course types', async () => {
+      let findCallCount = 0
+      const insertFn = mock.fn(async (data, opts) => ({
+        ...data,
+        _id: 'new-id'
+      }))
+      const inst = createInstance({
+        find: mock.fn(async () => {
+          findCallCount++
+          if (findCallCount === 1) return [{ _id: 'orig', _type: 'article', _courseId: 'c1', _friendlyId: 'art-1' }]
+          if (findCallCount === 2) return [{ _id: 'p', _type: 'page', _courseId: 'c1' }]
+          return []
+        }),
+        insert: insertFn,
+        preCloneHook: createMockHook(),
+        postCloneHook: createMockHook()
+      })
+
+      await ContentModule.prototype.clone.call(inst, 'user1', 'orig', 'p')
+
+      const payload = insertFn.mock.calls[0].arguments[0]
+      assert.equal(payload._friendlyId, undefined)
+    })
+
+    it('clone should preserve _friendlyId for course types', async () => {
+      let findCallCount = 0
+      const insertFn = mock.fn(async (data, opts) => ({
+        ...data,
+        _id: 'new-course-id'
+      }))
+      const inst = createInstance({
+        find: mock.fn(async () => {
+          findCallCount++
+          if (findCallCount === 1) return [{ _id: 'c1', _type: 'course', _courseId: 'c1', _friendlyId: 'course-1' }]
+          return []
+        }),
+        insert: insertFn,
+        update: mock.fn(async () => ({})),
+        preCloneHook: createMockHook(),
+        postCloneHook: createMockHook()
+      })
+
+      await ContentModule.prototype.clone.call(inst, 'user1', 'c1', undefined)
+
+      const payload = insertFn.mock.calls[0].arguments[0]
+      assert.equal(payload._friendlyId, 'course-1')
+    })
+
     it('should handle clone of course when no config exists', async () => {
       let findCallCount = 0
       const inst = createInstance({


### PR DESCRIPTION
Fix #93

### Fix
* Enforce `_friendlyId` uniqueness per course via a compound unique partial index on `{ _courseId, _friendlyId }`, preventing duplicate friendly IDs that break framework builds and multilang sync (fixes #93)

### Update
* `insert()` and `update()` now catch `MONGO_DUPL_INDEX` errors and throw a descriptive `DUPL_FRIENDLY_ID` error (409 Conflict)
* `clone()` clears `_friendlyId` for non-course content types when cloning within the same course, allowing hooks to regenerate unique values; course clones preserve `_friendlyId` since they belong to a new `_courseId`

### Testing
1. Run `npm test` in the content module — all 86 tests pass including 6 new tests covering:
   - `insert()` catches duplicate index errors and throws `DUPL_FRIENDLY_ID`
   - `insert()` re-throws non-duplicate errors unchanged
   - `update()` catches duplicate index errors and throws `DUPL_FRIENDLY_ID`
   - `update()` re-throws non-duplicate errors unchanged
   - `clone()` clears `_friendlyId` for non-course types
   - `clone()` preserves `_friendlyId` for course types
2. Run `npx standard` — passes with no errors