### PR TITLE
Fix: Forward options to updateSortOrder and updateEnabledPlugins

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -115,8 +115,8 @@ class ContentModule extends AbstractApiModule {
       return this.update({ _id: doc._id }, { _courseId: doc._id.toString() })
     }
     await Promise.all([
-      options.updateSortOrder !== false && this.updateSortOrder(doc, data),
-      options.updateEnabledPlugins !== false && this.updateEnabledPlugins(doc)
+      options.updateSortOrder !== false && this.updateSortOrder(doc, data, options, mongoOptions),
+      options.updateEnabledPlugins !== false && this.updateEnabledPlugins(doc, {}, options, mongoOptions)
     ])
     return doc
   }
@@ -133,8 +133,8 @@ class ContentModule extends AbstractApiModule {
       throw e
     }
     await Promise.all([
-      this.updateSortOrder(doc, data),
-      this.updateEnabledPlugins(doc, data._enabledPlugins ? { forceUpdate: true } : {})
+      this.updateSortOrder(doc, data, options, mongoOptions),
+      this.updateEnabledPlugins(doc, data._enabledPlugins ? { forceUpdate: true } : {}, options, mongoOptions)
     ])
     return doc
   }
@@ -154,8 +154,8 @@ class ContentModule extends AbstractApiModule {
       return super.delete({ _id: d._id }, options, mongoOptions)
     }))
     await Promise.all([
-      this.updateEnabledPlugins(targetDoc),
-      this.updateSortOrder(targetDoc)
+      this.updateEnabledPlugins(targetDoc, {}, options, mongoOptions),
+      this.updateSortOrder(targetDoc, undefined, options, mongoOptions)
     ])
     return [targetDoc, ...descendants]
   }
@@ -272,7 +272,7 @@ class ContentModule extends AbstractApiModule {
    * @param {Object} updateData The update data
    * @return {Promise}
    */
-  async updateSortOrder (item, updateData) {
+  async updateSortOrder (item, updateData, parentOptions, parentMongoOptions) {
     // some exceptions which don't need a _sortOrder
     if (item._type === 'config' || item._type === 'course' || !item._parentId) {
       return
@@ -284,7 +284,7 @@ class ContentModule extends AbstractApiModule {
     }
     return Promise.all(siblings.map(async (s, i) => {
       const _sortOrder = i + 1
-      if (s._sortOrder !== _sortOrder) return super.update({ _id: s._id }, { _sortOrder })
+      if (s._sortOrder !== _sortOrder) return super.update({ _id: s._id }, { _sortOrder }, parentOptions, parentMongoOptions)
     }))
   }
 
@@ -295,7 +295,7 @@ class ContentModule extends AbstractApiModule {
    * @param {Boolean} options.forceUpdate Forces an update of defaults regardless of whether the _enabledPlugins list has changed
    * @return {Promise}
    */
-  async updateEnabledPlugins ({ _courseId }, options = {}) {
+  async updateEnabledPlugins ({ _courseId }, options = {}, parentOptions, parentMongoOptions) {
     const [contentplugin, jsonschema] = await this.app.waitForModule('contentplugin', 'jsonschema')
     const contentItems = await this.find({ _courseId })
     const config = contentItems.find(c => c._type === 'config')
@@ -330,12 +330,12 @@ class ContentModule extends AbstractApiModule {
         }, types)
       }, [])
     // update config._enabledPlugins
-    await super.update({ _courseId, _type: 'config' }, { _enabledPlugins })
+    await super.update({ _courseId, _type: 'config' }, { _enabledPlugins }, parentOptions, parentMongoOptions)
     // update other affected content objects to ensure new defaults are applied
     // note: due to the complex data, each must be updated separately rather than using updateMany
     if (types.length > 0) {
       const toUpdate = await super.find({ _courseId, _type: { $in: types } }, {})
-      return Promise.all(toUpdate.map(c => super.update({ _id: c._id }, {})))
+      return Promise.all(toUpdate.map(c => super.update({ _id: c._id }, {}, parentOptions, parentMongoOptions)))
     }
   }
 


### PR DESCRIPTION
### Fix
* Forward caller `options`/`mongoOptions` through `updateSortOrder` and `updateEnabledPlugins` in all CRUD methods (fixes #106)

### Context
Follow-up to #105 / PR #104. The internal helpers `updateSortOrder` and `updateEnabledPlugins` call `super.update()` without forwarding the caller's `options`/`mongoOptions`. Any flags passed to the original CRUD call by hook observers are silently dropped, which can cause failures in modules that rely on those options being propagated.

### Testing
1. Add content with nested children (e.g. page > article > block > component) and verify no errors
2. Remove content with nested children and verify no errors
3. Verify sort order updates propagate correctly
4. Verify enabled plugins updates propagate correctly