### PR TITLE
Fix: Bulk-delete descendants to prevent OOM on content deletion

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -150,9 +150,16 @@ class ContentModule extends AbstractApiModule {
     }
     const descendants = await getDescendants(q => this.find(q), targetDoc)
 
-    await Promise.all([...descendants, targetDoc].map(d => {
-      return super.delete({ _id: d._id }, options, mongoOptions)
-    }))
+    // bulk-delete descendants directly to avoid per-item memory overhead and hook storms
+    if (descendants.length > 0) {
+      const mongodb = await this.app.waitForModule('mongodb')
+      await mongodb.deleteMany(this.collectionName, { _id: { $in: descendants.map(d => d._id) } }, mongoOptions)
+    }
+    // delete target via super.delete to trigger deleteHook middleware (e.g. multilang)
+    await super.delete({ _id: targetDoc._id }, options, mongoOptions)
+    if (descendants.length > 0 && options.invokePostHook !== false) {
+      await this.postDeleteHook.invoke(descendants)
+    }
     await Promise.all([
       this.updateEnabledPlugins(targetDoc, {}, options, mongoOptions),
       this.updateSortOrder(targetDoc, undefined, options, mongoOptions)


### PR DESCRIPTION
### Fixes #115

### Fix

- Replace `Promise.all(items.map(d => super.delete()))` with a single `mongodb.deleteMany()` for descendants
- Previously, deleting a block with N descendants fired N concurrent `super.delete()` calls, each of which loaded the doc from DB, fired pre/postDeleteHook, and triggered multilang's `onDelete` middleware — causing cascading full-course loads across all language variants
- Now descendants are bulk-deleted in one DB operation, and `postDeleteHook` is fired once with the full array instead of per-item
- The target item still goes through `super.delete()` to trigger `deleteHook` middleware (multilang sync)

### Testing

- [ ] Delete a block in a multilang course — should no longer OOM
- [ ] Delete a course — verify all content and descendants are removed
- [ ] Verify multilang peer sync still works (target item triggers multilang, peers are deleted)
- [ ] Verify courseassets are cleaned up for deleted descendants

🤖 Generated with [Claude Code](https://claude.com/claude-code)