### PR TITLE
New: Add /assetusage endpoint for an asset's course count (fixes #120)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -2,7 +2,7 @@ import { AbstractApiModule } from 'adapt-authoring-api'
 import { Hook, stringifyValues } from 'adapt-authoring-core'
 import { createObjectId, parseObjectId } from 'adapt-authoring-mongodb'
 import { ObjectId } from 'mongodb'
-import { ContentTree, computeSortOrderOps, contentTypeToSchemaName, extractAssetIds, formatFriendlyId, parseMaxSeq } from './utils.js'
+import { ContentTree, buildAssetUsagePipeline, computeSortOrderOps, contentTypeToSchemaName, extractAssetIds, formatFriendlyId, parseMaxSeq } from './utils.js'
 /**
  * Module which handles course content
  * @memberof content
@@ -102,6 +102,25 @@ class ContentModule extends AbstractApiModule {
       { projection: { title: 1, displayTitle: 1 } }
     )).map(c => c.displayTitle || c.title)
     throw this.app.errors.RESOURCE_IN_USE.setData({ type: 'asset', courses })
+  }
+
+  /**
+   * Returns a map of asset _id to the number of distinct courses each asset is referenced by.
+   * Reads the indexed `_assetIds` field. Accepts an optional `assetIds` array in the request body to
+   * scope the counts (e.g. the page of assets shown in the UI); assets with no usage are omitted.
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {function} next
+   * @return {Promise}
+   */
+  async handleAssetUsage (req, res, next) {
+    try {
+      const assetIds = Array.isArray(req.body?.assetIds) ? req.body.assetIds.map(id => parseObjectId(id)) : undefined
+      const results = await this.mongodb.getCollection(this.collectionName).aggregate(buildAssetUsagePipeline(assetIds)).toArray()
+      res.json(Object.fromEntries(results.map(r => [r._id.toString(), r.courseCount])))
+    } catch (e) {
+      next(e)
+    }
   }
 
   /** @override */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 export { default as ContentTree } from './ContentTree.js'
+export { default as buildAssetUsagePipeline } from './utils/buildAssetUsagePipeline.js'
 export { default as computeSortOrderOps } from './utils/computeSortOrderOps.js'
 export { extractAssetIds } from './utils/extractAssetIds.js'
 export { default as contentTypeToSchemaName } from './utils/contentTypeToSchemaName.js'

--- a/lib/utils/buildAssetUsagePipeline.js
+++ b/lib/utils/buildAssetUsagePipeline.js
@@ -1,0 +1,29 @@
+/**
+ * Builds the aggregation pipeline that counts, per asset, how many distinct courses reference it.
+ *
+ * Operates on the content collection's indexed `_assetIds` field (maintained on every content
+ * insert/update). The leading `$match` lets the query use the `_assetIds` index when scoped; the
+ * post-`$unwind` `$match` discards the other asset ids carried by matched documents so only the
+ * requested assets remain. Counting distinct `_courseId` via `$addToSet` (rather than documents)
+ * means an asset referenced by many content items within one course still counts as one course.
+ *
+ * Pure helper extracted from {@link ContentModule#handleAssetUsage} so it can be unit-tested without
+ * booting the app. Asset ids must already be coerced to ObjectId — `getCollection().aggregate()` is
+ * the raw driver and does not normalise ObjectId strings the way the module query layer does.
+ *
+ * @param {Array} [assetIds] Asset ObjectIds to scope the counts to. Omit/empty to count all assets.
+ * @returns {Array<Object>} Aggregation pipeline producing `{ _id: <assetId>, courseCount }` rows
+ * @memberof content
+ */
+export default function buildAssetUsagePipeline (assetIds) {
+  const match = Array.isArray(assetIds) && assetIds.length > 0
+    ? { $match: { _assetIds: { $in: assetIds } } }
+    : null
+  return [
+    ...(match ? [match] : []),
+    { $unwind: '$_assetIds' },
+    ...(match ? [match] : []),
+    { $group: { _id: '$_assetIds', courses: { $addToSet: '$_courseId' } } },
+    { $project: { courseCount: { $size: '$courses' } } }
+  ]
+}

--- a/routes.json
+++ b/routes.json
@@ -110,6 +110,29 @@
           }
         }
       }
+    },
+    {
+      "route": "/assetusage",
+      "handlers": { "post": "handleAssetUsage" },
+      "permissions": { "post": ["read:${scope}"] },
+      "meta": {
+        "post": {
+          "summary": "Count how many distinct courses each asset is used in",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "assetIds": { "type": "array", "items": { "type": "string" }, "description": "Optional list of asset _ids to scope the counts to. Omit to count all assets." }
+                  }
+                }
+              }
+            }
+          },
+          "responses": { "200": { "description": "Object mapping asset _id to the number of distinct courses referencing it; assets with no usage are omitted" } }
+        }
+      }
     }
   ]
 }

--- a/tests/utils-buildAssetUsagePipeline.spec.js
+++ b/tests/utils-buildAssetUsagePipeline.spec.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import buildAssetUsagePipeline from '../lib/utils/buildAssetUsagePipeline.js'
+
+const GROUP = { $group: { _id: '$_assetIds', courses: { $addToSet: '$_courseId' } } }
+const PROJECT = { $project: { courseCount: { $size: '$courses' } } }
+
+describe('buildAssetUsagePipeline', () => {
+  for (const [name, input] of [
+    ['no argument', undefined],
+    ['null', null],
+    ['empty array', []]
+  ]) {
+    it(`counts all assets when given ${name} (no $match, single $unwind)`, () => {
+      const pipeline = buildAssetUsagePipeline(input)
+      assert.deepEqual(pipeline, [
+        { $unwind: '$_assetIds' },
+        GROUP,
+        PROJECT
+      ])
+      assert.equal(pipeline.filter(s => s.$match).length, 0)
+    })
+  }
+
+  it('scopes with a $match before and after $unwind when asset ids are given', () => {
+    const ids = ['id-a', 'id-b']
+    const pipeline = buildAssetUsagePipeline(ids)
+    const expectedMatch = { $match: { _assetIds: { $in: ids } } }
+    assert.deepEqual(pipeline, [
+      expectedMatch,
+      { $unwind: '$_assetIds' },
+      expectedMatch,
+      GROUP,
+      PROJECT
+    ])
+  })
+
+  it('places the pre-$unwind $match first so the _assetIds index can be used', () => {
+    const pipeline = buildAssetUsagePipeline(['id-a'])
+    assert.ok(pipeline[0].$match, 'first stage should be a $match')
+    assert.equal(pipeline[1].$unwind, '$_assetIds')
+  })
+
+  it('counts distinct courses (uses $addToSet on _courseId, not a document count)', () => {
+    const group = buildAssetUsagePipeline().find(s => s.$group)
+    assert.deepEqual(group.$group.courses, { $addToSet: '$_courseId' })
+  })
+})


### PR DESCRIPTION
### Fixes #120

### New
* Adds `POST /api/content/assetusage`, returning a map of asset `_id` → number of **distinct** courses referencing it.
* Optional `assetIds` body array scopes the counts to specific assets (e.g. the page shown in the UI); omit to count all.
* Computed in a single aggregation over the indexed `_assetIds` field; distinct courses via `$addToSet` of `_courseId` so an asset used by many content items in one course counts once.
* New pure helper `lib/utils/buildAssetUsagePipeline.js` (unit-tested), and `handleAssetUsage` — a sibling of the existing `enforceAssetNotInUse` asset-deletion guard, which does the same `_assetIds` → `_courseId` lookup.

### Testing
1. `node --test tests/**/*.spec.js` — covers `buildAssetUsagePipeline` (scoped/unscoped shape, index-friendly $match ordering, distinct-course counting).
2. Manual: `POST /api/content/assetusage` with `{ "assetIds": ["<id>"] }` → count for those assets; an asset used by multiple blocks in one course reports `1`, across two courses reports `2`.