### PR TITLE
New: Prevent building courses with empty containers (fixes #122)

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -21,5 +21,12 @@
     },
     "description": "Resource is currently being used in courses",
     "statusCode": 400
+  },
+  "EMPTY_CONTAINERS": {
+    "data": {
+      "items": "The childless content items blocking the build"
+    },
+    "description": "Course cannot be built: one or more pages, articles or blocks have no content",
+    "statusCode": 400
   }
 }

--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -59,6 +59,12 @@ class ContentModule extends AbstractApiModule {
 
     assets.preDeleteHook.tap(this.enforceAssetNotInUse.bind(this))
 
+    // block builds when the course structure has empty containers. adaptframework depends on
+    // content (not vice-versa), so tap its hook once available rather than awaiting it here.
+    this.app.waitForModule('adaptframework').then(framework => {
+      framework.preBuildHook.tap(this.enforceNoEmptyContainers.bind(this))
+    })
+
     await mongodb.setIndex(this.collectionName, { _courseId: 1, _parentId: 1, _type: 1 })
     await mongodb.setIndex(this.collectionName, { _parentId: 1 })
     await mongodb.setIndex(this.collectionName, { _type: 1, _courseId: 1 })
@@ -102,6 +108,26 @@ class ContentModule extends AbstractApiModule {
       { projection: { title: 1, displayTitle: 1 } }
     )).map(c => c.displayTitle || c.title)
     throw this.app.errors.RESOURCE_IN_USE.setData({ type: 'asset', courses })
+  }
+
+  /**
+   * preBuildHook observer: refuses a build when any non-component content item has no children
+   * (an empty page, article or block). Components are leaf nodes and config is exempt.
+   * @param {AdaptFrameworkBuild} build The build being run
+   * @return {Promise}
+   */
+  async enforceNoEmptyContainers (build) {
+    const _courseId = parseObjectId(build.courseId)
+    const items = await this.find(
+      { $or: [{ _id: _courseId }, { _courseId }] },
+      { validate: false },
+      { projection: { _type: 1, _parentId: 1, title: 1, displayTitle: 1 } }
+    )
+    const empty = new ContentTree(items).getEmptyContainers()
+    if (!empty.length) return
+    throw this.app.errors.EMPTY_CONTAINERS.setData({
+      items: empty.map(i => ({ _id: i._id.toString(), _type: i._type, title: i.displayTitle || i.title }))
+    })
   }
 
   /**

--- a/lib/ContentTree.js
+++ b/lib/ContentTree.js
@@ -115,6 +115,20 @@ class ContentTree {
   }
 
   /**
+   * Finds container items that have no children. Components are leaf nodes and
+   * config is a childless root — both are exempt; every other type (course, menu,
+   * page, article, block) is expected to contain at least one child.
+   * @returns {Array<Object>} Childless container items
+   */
+  getEmptyContainers () {
+    return this.items.filter(i =>
+      i._type !== 'component' &&
+      i._type !== 'config' &&
+      this.getChildren(i._id).length === 0
+    )
+  }
+
+  /**
    * O(1) — unique component names across the course
    * @returns {Array<string>}
    */

--- a/tests/ContentTree.spec.js
+++ b/tests/ContentTree.spec.js
@@ -227,4 +227,53 @@ describe('ContentTree', () => {
       assert.deepEqual(tree.getComponentNames(), [])
     })
   })
+
+  describe('getEmptyContainers', () => {
+    it('should return container items that have no children', () => {
+      // in the shared fixture the menu (id4) and second article (id6) are childless
+      const empty = new ContentTree(items).getEmptyContainers()
+      assert.deepEqual(empty.map(i => i._id.toString()).sort(), ['id4', 'id6'])
+    })
+
+    it('should never flag components (leaf nodes)', () => {
+      const tree = new ContentTree([
+        { _id: makeId(1), _type: 'block', _parentId: makeId(99) },
+        { _id: makeId(2), _type: 'component', _parentId: makeId(1), _component: 'adapt-contrib-text' }
+      ])
+      assert.equal(tree.getEmptyContainers().length, 0)
+    })
+
+    it('should never flag config (childless root)', () => {
+      const tree = new ContentTree([
+        { _id: makeId(1), _type: 'course' },
+        { _id: makeId(2), _type: 'config', _courseId: 'c1' },
+        { _id: makeId(3), _type: 'page', _parentId: makeId(1) },
+        { _id: makeId(4), _type: 'article', _parentId: makeId(3) },
+        { _id: makeId(5), _type: 'block', _parentId: makeId(4) },
+        { _id: makeId(6), _type: 'component', _parentId: makeId(5), _component: 'adapt-contrib-text' }
+      ])
+      assert.deepEqual(tree.getEmptyContainers(), [])
+    })
+
+    it('should flag a block with no components', () => {
+      const tree = new ContentTree([
+        { _id: makeId(1), _type: 'article', _parentId: makeId(99) },
+        { _id: makeId(2), _type: 'block', _parentId: makeId(1) }
+      ])
+      const empty = tree.getEmptyContainers()
+      assert.equal(empty.length, 1)
+      assert.equal(empty[0]._id.toString(), 'id2')
+    })
+
+    it('should flag a course with no children', () => {
+      const tree = new ContentTree([
+        { _id: makeId(1), _type: 'course' }
+      ])
+      assert.deepEqual(tree.getEmptyContainers().map(i => i._type), ['course'])
+    })
+
+    it('should return empty array for an empty tree', () => {
+      assert.deepEqual(new ContentTree([]).getEmptyContainers(), [])
+    })
+  })
 })


### PR DESCRIPTION
### Fixes #122

### New
- Refuse a course build (preview, publish and export) when any structural item has no children — an empty page, article or block. Components (leaf nodes) and config (childless root) are exempt; course/menu/page/article/block must contain at least one child.
- Enforced server-side by tapping the existing `adaptframework.preBuildHook`, so the build cannot run regardless of client. The tap is non-blocking (adaptframework depends on content, not vice-versa). Re-queries content fresh rather than using the builder's already-transformed data.
- Adds `ContentTree.getEmptyContainers()` (pure) and a new `EMPTY_CONTAINERS` (400) error listing the offending items.

### Testing
- New unit tests for `ContentTree.getEmptyContainers()` covering childless containers, component/config exemptions, empty blocks/courses and empty trees.
- Full suite: 143 tests pass; `standard` clean.