### PR TITLE
Fix: Enforce access check on the content tree endpoint

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -665,8 +665,18 @@ class ContentModule extends AbstractApiModule {
       const course = await this.findOne(
         { _type: 'course', _courseId },
         { validate: false },
-        { projection: { updatedAt: 1 } }
+        { projection: { updatedAt: 1, _type: 1, createdBy: 1, _isShared: 1, _shareWithUsers: 1, userGroups: 1 } }
       )
+      if (!course) {
+        throw this.app.errors.NOT_FOUND.setData({ type: 'content', id: _courseId })
+      }
+      // this custom handler bypasses the standard per-item access check, so apply
+      // it here: the tree is readable only if the user can access the course
+      // (owner / _isShared / _shareWithUsers / shared group). 404 (not 403) so we
+      // don't leak the course's existence. Supers are exempt.
+      if (!req.auth.isSuper && this.accessCheckHook.hasObservers && !(await this.accessCheckHook.invoke(req, course)).every(Boolean)) {
+        throw this.app.errors.NOT_FOUND.setData({ type: 'content', id: _courseId })
+      }
       const lastModified = new Date(course.updatedAt)
       lastModified.setMilliseconds(0) // HTTP dates are second-precision; must match before comparing
       const ifModifiedSince = req.headers['if-modified-since'] && new Date(req.headers['if-modified-since'])

--- a/tests/ContentModule.spec.js
+++ b/tests/ContentModule.spec.js
@@ -560,6 +560,7 @@ describe('ContentModule', () => {
       let statusCode
       let ended = false
       const req = {
+        auth: { isSuper: true },
         apiData: { query: { _courseId: COURSE_ID } },
         headers: { 'if-modified-since': new Date('2025-01-02T00:00:00Z').toUTCString() }
       }
@@ -586,6 +587,7 @@ describe('ContentModule', () => {
         find: mock.fn(async () => items)
       })
       const req = {
+        auth: { isSuper: true },
         apiData: { query: { _courseId: COURSE_ID } },
         headers: {}
       }
@@ -617,12 +619,64 @@ describe('ContentModule', () => {
       const inst = createInstance({
         findOne: mock.fn(async () => { throw new Error('db error') })
       })
-      const req = { apiData: { query: { _courseId: COURSE_ID } }, headers: {} }
+      const req = { auth: { isSuper: true }, apiData: { query: { _courseId: COURSE_ID } }, headers: {} }
       const res = {}
       const next = mock.fn()
       await ContentModule.prototype.handleTree.call(inst, req, res, next)
       assert.equal(next.mock.callCount(), 1)
       assert.equal(next.mock.calls[0].arguments[0].message, 'db error')
+    })
+
+    it('should run the per-item access check for non-super users and return the tree when allowed', async () => {
+      const lastModified = new Date('2025-01-15T00:00:00Z')
+      const course = { _id: COURSE_ID, _type: 'course', updatedAt: lastModified }
+      const accessCheckHook = { hasObservers: true, invoke: mock.fn(async () => [true]) }
+      const inst = createInstance({
+        accessCheckHook,
+        findOne: mock.fn(async () => course),
+        find: mock.fn(async () => [{ _id: COURSE_ID, _type: 'course', _courseId: COURSE_ID }])
+      })
+      const req = { auth: { isSuper: false, user: {} }, apiData: { query: { _courseId: COURSE_ID } }, headers: {} }
+      const res = { set: mock.fn(), json: mock.fn() }
+      const next = mock.fn()
+      await ContentModule.prototype.handleTree.call(inst, req, res, next)
+
+      assert.equal(accessCheckHook.invoke.mock.callCount(), 1, 'access check invoked')
+      assert.deepEqual(accessCheckHook.invoke.mock.calls[0].arguments, [req, course], 'check receives req + the course')
+      assert.equal(inst.find.mock.callCount(), 1)
+      assert.equal(next.mock.callCount(), 0)
+    })
+
+    it('should 404 (not leak existence) when the access check denies the course', async () => {
+      const accessCheckHook = { hasObservers: true, invoke: mock.fn(async () => [false]) }
+      const inst = createInstance({
+        accessCheckHook,
+        findOne: mock.fn(async () => ({ _id: COURSE_ID, _type: 'course', updatedAt: new Date() })),
+        app: { errors: { NOT_FOUND: { setData: () => new Error('NOT_FOUND') } } }
+      })
+      const req = { auth: { isSuper: false, user: {} }, apiData: { query: { _courseId: COURSE_ID } }, headers: {} }
+      const next = mock.fn()
+      await ContentModule.prototype.handleTree.call(inst, req, {}, next)
+
+      assert.equal(next.mock.callCount(), 1)
+      assert.equal(next.mock.calls[0].arguments[0].message, 'NOT_FOUND')
+      assert.equal(inst.find.mock.callCount(), 0, 'should not fetch items for an inaccessible course')
+    })
+
+    it('should skip the access check for super users', async () => {
+      const accessCheckHook = { hasObservers: true, invoke: mock.fn(async () => [false]) }
+      const inst = createInstance({
+        accessCheckHook,
+        findOne: mock.fn(async () => ({ _id: COURSE_ID, _type: 'course', updatedAt: new Date('2025-01-15T00:00:00Z') })),
+        find: mock.fn(async () => [])
+      })
+      const req = { auth: { isSuper: true }, apiData: { query: { _courseId: COURSE_ID } }, headers: {} }
+      const res = { set: mock.fn(), json: mock.fn() }
+      const next = mock.fn()
+      await ContentModule.prototype.handleTree.call(inst, req, res, next)
+
+      assert.equal(accessCheckHook.invoke.mock.callCount(), 0, 'super bypasses the access check')
+      assert.equal(next.mock.callCount(), 0)
     })
   })
 


### PR DESCRIPTION
### Fixes #124

### Fix
- `handleTree` (the `/tree/:_courseId` endpoint) now runs the per-item `accessCheckHook` for non-super users and returns 404 when the user cannot access the course — closing a leak where the tree endpoint bypassed access gating entirely and exposed any course's full content tree. 404 (not 403) so the course's existence isn't leaked; super users are exempt, matching the standard handlers.

### Testing
- Added unit tests for the allowed / denied / super-bypass paths.
- Full module suite green (`node --test`, 146 tests).