### PR TITLE
Fix: Insert cloned content at its requested position

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -571,6 +571,8 @@ class ContentModule extends AbstractApiModule {
     if (originalDoc._courseId?.toString() !== payloads[0]._courseId?.toString()) {
       await this.updateEnabledPlugins(payloads[0])
     }
+    // place the clone at its requested _sortOrder and renumber siblings (no-op for course/config)
+    await this.updateSortOrder(payloads[0], payloads[0])
 
     return payloads[0]
   }

--- a/tests/ContentModule.spec.js
+++ b/tests/ContentModule.spec.js
@@ -384,6 +384,7 @@ describe('ContentModule', () => {
         }),
         getSchema: mock.fn(async () => ({})),
         updateEnabledPlugins: mock.fn(async () => {}),
+        updateSortOrder: mock.fn(async () => {}),
         preCloneHook: { invoke: mock.fn(async () => {}) },
         preInsertHook: { invoke: mock.fn(async () => {}) },
         postInsertHook: { invoke: mock.fn(async () => {}) },
@@ -458,6 +459,25 @@ describe('ContentModule', () => {
       // course + config + page = 3
       assert.equal(inserted.length, 3)
       assert.equal(result._type, 'course')
+    })
+
+    it('should renumber siblings for the cloned root so it lands at its _sortOrder', async () => {
+      const { inst } = createCloneInstance()
+
+      const items = [
+        { _id: COURSE_OID, _type: 'course', _courseId: COURSE_OID },
+        { _id: PAGE_OID, _type: 'page', _parentId: COURSE_OID, _courseId: COURSE_OID }
+      ]
+      const tree = new ContentTree(items)
+      const parent = { _id: COURSE_OID, _type: 'course', _courseId: COURSE_OID }
+      const result = await ContentModule.prototype.clone.call(inst, USER_OID, PAGE_OID, COURSE_OID, { _sortOrder: 1 }, { tree, parent })
+
+      assert.equal(inst.updateSortOrder.mock.callCount(), 1)
+      const [item, updateData] = inst.updateSortOrder.mock.calls[0].arguments
+      // called with the root payload (truthy updateData triggers the splice/renumber path)
+      assert.equal(item, result)
+      assert.ok(updateData)
+      assert.equal(item._sortOrder, 1)
     })
 
     it('should remap parent IDs correctly', async () => {


### PR DESCRIPTION
### Fixes #126

### Fix
- `clone()` now calls `updateSortOrder()` on the cloned root so pasted/cloned items land at their requested `_sortOrder` and siblings are renumbered. No-op for course/config roots.

### Testing
- Added a unit test asserting `clone()` invokes `updateSortOrder` with the root payload.
- Full suite passes (147 tests).