### PR TITLE
Fix: Include heroImage in tree projection (fixes #128)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -2,7 +2,7 @@ import { AbstractApiModule } from 'adapt-authoring-api'
 import { Hook, stringifyValues } from 'adapt-authoring-core'
 import { createObjectId, parseObjectId } from 'adapt-authoring-mongodb'
 import { ObjectId } from 'mongodb'
-import { ContentTree, buildAssetUsagePipeline, computeSortOrderOps, contentTypeToSchemaName, extractAssetIds, formatFriendlyId, parseMaxSeq } from './utils.js'
+import { ContentTree, buildAssetUsagePipeline, computeSortOrderOps, contentTypeToSchemaName, extractAssetIds, fieldsToProjection, formatFriendlyId, parseMaxSeq } from './utils.js'
 /**
  * Module which handles course content
  * @memberof content
@@ -685,10 +685,28 @@ class ContentModule extends AbstractApiModule {
       if (ifModifiedSince && lastModified <= ifModifiedSince) {
         return res.status(304).end()
       }
+      const treeFields = [
+        '_id',
+        '_parentId',
+        '_courseId',
+        '_type',
+        '_sortOrder',
+        'title',
+        'displayTitle',
+        '_friendlyId',
+        '_component',
+        '_layout',
+        '_menu',
+        '_theme',
+        '_enabledPlugins',
+        '_colorLabel',
+        'heroImage',
+        'updatedAt'
+      ]
       const items = await this.find(
         { _courseId },
         { validate: false },
-        { projection: { _id: 1, _parentId: 1, _courseId: 1, _type: 1, _sortOrder: 1, title: 1, displayTitle: 1, _friendlyId: 1, _component: 1, _layout: 1, _menu: 1, _theme: 1, _enabledPlugins: 1, _colorLabel: 1, updatedAt: 1 } }
+        { projection: fieldsToProjection(treeFields) }
       )
       const tree = new ContentTree(items)
       res.set('Last-Modified', lastModified.toUTCString())

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,5 +3,6 @@ export { default as buildAssetUsagePipeline } from './utils/buildAssetUsagePipel
 export { default as computeSortOrderOps } from './utils/computeSortOrderOps.js'
 export { extractAssetIds } from './utils/extractAssetIds.js'
 export { default as contentTypeToSchemaName } from './utils/contentTypeToSchemaName.js'
+export { default as fieldsToProjection } from './utils/fieldsToProjection.js'
 export { default as formatFriendlyId } from './utils/formatFriendlyId.js'
 export { default as parseMaxSeq } from './utils/parseMaxSeq.js'

--- a/lib/utils/fieldsToProjection.js
+++ b/lib/utils/fieldsToProjection.js
@@ -1,0 +1,10 @@
+/**
+ * Builds a MongoDB inclusion projection from a list of field names, mapping
+ * each to `1` (e.g. `['_id', 'title']` -> `{ _id: 1, title: 1 }`). Lets a
+ * handler declare its projected fields as a readable one-per-line array.
+ * @param {Array<string>} fields Field names to include
+ * @return {Object} Inclusion projection
+ */
+export default function fieldsToProjection (fields) {
+  return Object.fromEntries((fields ?? []).map(field => [field, 1]))
+}

--- a/tests/utils-fieldsToProjection.spec.js
+++ b/tests/utils-fieldsToProjection.spec.js
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fieldsToProjection from '../lib/utils/fieldsToProjection.js'
+
+describe('fieldsToProjection', () => {
+  it('maps each field name to 1', () => {
+    assert.deepEqual(fieldsToProjection(['_id', 'title']), { _id: 1, title: 1 })
+  })
+
+  it('returns an empty projection for an empty array', () => {
+    assert.deepEqual(fieldsToProjection([]), {})
+  })
+
+  it('treats a missing argument as empty', () => {
+    assert.deepEqual(fieldsToProjection(), {})
+    assert.deepEqual(fieldsToProjection(undefined), {})
+  })
+
+  it('collapses duplicate field names to a single key', () => {
+    assert.deepEqual(fieldsToProjection(['_id', '_id', 'title']), { _id: 1, title: 1 })
+  })
+})


### PR DESCRIPTION
### Fixes #128

### Fix
* `handleTree` projected a fixed field list that omitted `heroImage`; added it so the tree returns the course hero image.

### Chore
* Refactored the projection to a readable one-field-per-line `treeFields` array, converted via a new `fieldsToProjection` util (barrel-exported, unit-tested).

### Testing
1. `node --experimental-test-module-mocks --test 'tests/**/*.spec.js'`