### PR TITLE
Fix: invalidate content tree cache on response-shape change

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -2,7 +2,7 @@ import { AbstractApiModule } from 'adapt-authoring-api'
 import { Hook, stringifyValues } from 'adapt-authoring-core'
 import { createObjectId, parseObjectId } from 'adapt-authoring-mongodb'
 import { ObjectId } from 'mongodb'
-import { ContentTree, buildAssetUsagePipeline, computeSortOrderOps, contentTypeToSchemaName, extractAssetIds, fieldsToProjection, formatFriendlyId, parseMaxSeq } from './utils.js'
+import { ContentTree, buildAssetUsagePipeline, computeSortOrderOps, contentTypeToSchemaName, extractAssetIds, fieldsToProjection, formatFriendlyId, parseMaxSeq, treeEtag } from './utils.js'
 /**
  * Module which handles course content
  * @memberof content
@@ -679,12 +679,6 @@ class ContentModule extends AbstractApiModule {
       if (!req.auth.isSuper && this.accessCheckHook.hasObservers && !(await this.accessCheckHook.invoke(req, course)).every(Boolean)) {
         throw this.app.errors.NOT_FOUND.setData({ type: 'content', id: _courseId })
       }
-      const lastModified = new Date(course.updatedAt)
-      lastModified.setMilliseconds(0) // HTTP dates are second-precision; must match before comparing
-      const ifModifiedSince = req.headers['if-modified-since'] && new Date(req.headers['if-modified-since'])
-      if (ifModifiedSince && lastModified <= ifModifiedSince) {
-        return res.status(304).end()
-      }
       const treeFields = [
         '_id',
         '_parentId',
@@ -703,13 +697,21 @@ class ContentModule extends AbstractApiModule {
         'heroImage',
         'updatedAt'
       ]
+      // ETag (not Last-Modified): folds the projected field list into the
+      // validator so the cache busts when the response shape changes, not just
+      // when the course data does — otherwise an added field stays missing for
+      // unedited courses whose updatedAt never moves.
+      const etag = treeEtag(course.updatedAt, treeFields)
+      if (req.headers['if-none-match'] === etag) {
+        return res.status(304).end()
+      }
       const items = await this.find(
         { _courseId },
         { validate: false },
         { projection: fieldsToProjection(treeFields) }
       )
       const tree = new ContentTree(items)
-      res.set('Last-Modified', lastModified.toUTCString())
+      res.set('ETag', etag)
       res.json(items.map(item => ({
         ...item,
         _children: tree.getChildren(item._id).map(c => c._id)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,3 +6,4 @@ export { default as contentTypeToSchemaName } from './utils/contentTypeToSchemaN
 export { default as fieldsToProjection } from './utils/fieldsToProjection.js'
 export { default as formatFriendlyId } from './utils/formatFriendlyId.js'
 export { default as parseMaxSeq } from './utils/parseMaxSeq.js'
+export { default as treeEtag } from './utils/treeEtag.js'

--- a/lib/utils/treeEtag.js
+++ b/lib/utils/treeEtag.js
@@ -1,0 +1,16 @@
+import { createHash } from 'crypto'
+/**
+ * Builds a weak ETag for the content tree response. Combines the course's
+ * `updatedAt` with a hash of the projected field list, so the cache
+ * invalidates both when the course data changes AND when the tree response
+ * *shape* changes (e.g. a field is added to the projection). Keying solely on
+ * `updatedAt` served stale bodies to unedited courses after a shape change —
+ * a newly-projected field was missing until the course happened to be edited.
+ * @param {Date|string|number} updatedAt Course updatedAt
+ * @param {Array<string>} fields Projected tree field names
+ * @return {string} Weak ETag value (quoted, `W/`-prefixed)
+ */
+export default function treeEtag (updatedAt, fields) {
+  const shape = createHash('sha1').update([...(fields ?? [])].sort().join(',')).digest('hex').slice(0, 8)
+  return `W/"${new Date(updatedAt).getTime()}-${shape}"`
+}

--- a/tests/ContentModule.spec.js
+++ b/tests/ContentModule.spec.js
@@ -572,17 +572,24 @@ describe('ContentModule', () => {
   })
 
   describe('handleTree', () => {
-    it('should return 304 when content has not been modified', async () => {
-      const lastModified = new Date('2025-01-01T00:00:00Z')
+    it('should return 304 when the ETag matches (content + shape unchanged)', async () => {
       const inst = createInstance({
-        findOne: mock.fn(async () => ({ updatedAt: lastModified }))
+        findOne: mock.fn(async () => ({ updatedAt: new Date('2025-01-01T00:00:00Z') })),
+        find: mock.fn(async () => [])
       })
+      // capture the current ETag from a fresh request...
+      let etag
+      const firstRes = { set: mock.fn((k, v) => { if (k === 'ETag') etag = v }), json: mock.fn() }
+      await ContentModule.prototype.handleTree.call(inst, { auth: { isSuper: true }, apiData: { query: { _courseId: COURSE_ID } }, headers: {} }, firstRes, mock.fn())
+      assert.match(etag, /^W\/".+"$/)
+
+      // ...then a conditional request carrying it gets a 304
       let statusCode
       let ended = false
       const req = {
         auth: { isSuper: true },
         apiData: { query: { _courseId: COURSE_ID } },
-        headers: { 'if-modified-since': new Date('2025-01-02T00:00:00Z').toUTCString() }
+        headers: { 'if-none-match': etag }
       }
       const res = {
         status: mock.fn(function (code) { statusCode = code; return this }),
@@ -592,6 +599,31 @@ describe('ContentModule', () => {
       await ContentModule.prototype.handleTree.call(inst, req, res, next)
       assert.equal(statusCode, 304)
       assert.equal(ended, true)
+      assert.equal(next.mock.callCount(), 0)
+    })
+
+    it('should serve the tree (not 304) when the ETag no longer matches the response shape', async () => {
+      // a cached ETag from before a treeFields change must not short-circuit to
+      // 304 — otherwise the new field stays missing for unedited courses
+      const inst = createInstance({
+        findOne: mock.fn(async () => ({ updatedAt: new Date('2025-01-01T00:00:00Z') })),
+        find: mock.fn(async () => [{ _id: COURSE_ID, _type: 'course', _courseId: COURSE_ID }])
+      })
+      let statusCode
+      const req = {
+        auth: { isSuper: true },
+        apiData: { query: { _courseId: COURSE_ID } },
+        headers: { 'if-none-match': 'W/"1735689600000-deadbeef"' }
+      }
+      const res = {
+        status: mock.fn(function (code) { statusCode = code; return this }),
+        set: mock.fn(),
+        json: mock.fn()
+      }
+      const next = mock.fn()
+      await ContentModule.prototype.handleTree.call(inst, req, res, next)
+      assert.equal(statusCode, undefined, 'did not 304')
+      assert.equal(res.json.mock.callCount(), 1, 'served the tree')
       assert.equal(next.mock.callCount(), 0)
     })
 
@@ -612,9 +644,9 @@ describe('ContentModule', () => {
         headers: {}
       }
       let responseData
-      let lastModifiedHeader
+      let etagHeader
       const res = {
-        set: mock.fn((key, val) => { if (key === 'Last-Modified') lastModifiedHeader = val }),
+        set: mock.fn((key, val) => { if (key === 'ETag') etagHeader = val }),
         json: mock.fn((data) => { responseData = data })
       }
       const next = mock.fn()
@@ -631,8 +663,8 @@ describe('ContentModule', () => {
       // article should have no children
       const art = responseData.find(i => i._id === 'art1')
       assert.deepEqual(art._children, [])
-      // Last-Modified header should be set
-      assert.equal(lastModifiedHeader, lastModified.toUTCString())
+      // ETag header should be set
+      assert.match(etagHeader, /^W\/".+"$/)
     })
 
     it('should call next on error', async () => {

--- a/tests/utils-treeEtag.spec.js
+++ b/tests/utils-treeEtag.spec.js
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import treeEtag from '../lib/utils/treeEtag.js'
+
+const updatedAt = new Date('2026-06-18T17:34:00.123Z')
+
+describe('treeEtag', () => {
+  it('produces a quoted weak ETag', () => {
+    assert.match(treeEtag(updatedAt, ['_id', 'title']), /^W\/".+"$/)
+  })
+
+  it('is stable for the same inputs', () => {
+    assert.equal(treeEtag(updatedAt, ['_id', 'title']), treeEtag(updatedAt, ['_id', 'title']))
+  })
+
+  it('is independent of field order', () => {
+    assert.equal(treeEtag(updatedAt, ['_id', 'title']), treeEtag(updatedAt, ['title', '_id']))
+  })
+
+  it('changes when the field set changes (shape bust)', () => {
+    assert.notEqual(treeEtag(updatedAt, ['_id', 'title']), treeEtag(updatedAt, ['_id', 'title', 'heroImage']))
+  })
+
+  it('changes when updatedAt changes (data bust)', () => {
+    assert.notEqual(treeEtag(updatedAt, ['_id']), treeEtag(new Date('2026-06-19T00:00:00Z'), ['_id']))
+  })
+
+  it('accepts Date, string and numeric timestamps equivalently', () => {
+    const fields = ['_id', 'title']
+    assert.equal(treeEtag(updatedAt, fields), treeEtag(updatedAt.toISOString(), fields))
+    assert.equal(treeEtag(updatedAt, fields), treeEtag(updatedAt.getTime(), fields))
+  })
+
+  it('treats a missing field list as empty', () => {
+    assert.match(treeEtag(updatedAt), /^W\/".+"$/)
+    assert.equal(treeEtag(updatedAt), treeEtag(updatedAt, []))
+  })
+})


### PR DESCRIPTION
### Fixes #131

### Fix
- `handleTree` now sets an `ETag` and honours `If-None-Match` instead of `Last-Modified`/`If-Modified-Since`. The ETag folds a hash of the projected `treeFields` into the validator alongside `course.updatedAt`, so the cache busts on response-**shape** changes (e.g. adding `heroImage`) as well as on data changes — fixing stale tree bodies being served to unedited courses.
- New pure util `lib/utils/treeEtag.js` (barrel-exported) builds the weak ETag; order-independent over the field list.
- Self-healing on deploy: browsers holding a pre-change `Last-Modified`-only cache send `If-Modified-Since`, which the handler no longer reads, so they receive a fresh `200` (no manual cache clear needed).

### Testing
- Added `tests/utils-treeEtag.spec.js` (stability, field-order independence, shape bust, data bust, timestamp-type equivalence, empty fields).
- Updated the `handleTree` 304 test to the `If-None-Match`/ETag contract and added a regression test asserting a stale/mismatched ETag does **not** short-circuit to `304`.
- Full suite passes (159/159); `npx standard` clean.
