### PR TITLE
Update: include _language in the content tree projection

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -694,6 +694,7 @@ class ContentModule extends AbstractApiModule {
         '_theme',
         '_enabledPlugins',
         '_colorLabel',
+        '_language',
         'heroImage',
         'updatedAt'
       ]


### PR DESCRIPTION
### Update
- Add `_language` to the `treeFields` projection in `handleTree` so the content tree exposes a course's language code. Consumers can read `_language` off the course node instead of an extra per-course fetch.
- The field list is already folded into the response ETag (`treeEtag`), so the tree cache invalidates automatically for the new shape — no stale-304.