### PR TITLE
New: endpoint listing the courses that reference an asset

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -151,6 +151,32 @@ class ContentModule extends AbstractApiModule {
   }
 
   /**
+   * Returns the courses that reference a given asset as `{ _id, title }` rows, for the asset sheet's "used in courses" list.
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {function} next
+   * @return {Promise}
+   */
+  async handleAssetCourses (req, res, next) {
+    try {
+      const usedBy = await this.find(
+        { _assetIds: req.apiData.query._id },
+        { validate: false },
+        { projection: { _courseId: 1 } }
+      )
+      const courseIds = [...new Set(usedBy.map(d => d._courseId?.toString()).filter(Boolean))].map(id => parseObjectId(id))
+      const courses = await this.find(
+        { _type: 'course', _id: { $in: courseIds } },
+        { validate: false },
+        { projection: { title: 1, displayTitle: 1 } }
+      )
+      res.json(courses.map(c => ({ _id: c._id.toString(), title: c.displayTitle || c.title })))
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
    * "Unused assets" filter for the asset manager. The UI sends a `?unused`
    * query-string flag (see adapt-authoring-ui Assets page); restrict the assets
    * query to those not referenced by any content document. Read from req.query

--- a/routes.json
+++ b/routes.json
@@ -133,6 +133,18 @@
           "responses": { "200": { "description": "Object mapping asset _id to the number of distinct courses referencing it; assets with no usage are omitted" } }
         }
       }
+    },
+    {
+      "route": "/assetusage/:_id",
+      "handlers": { "get": "handleAssetCourses" },
+      "permissions": { "get": ["read:${scope}"] },
+      "meta": {
+        "get": {
+          "summary": "List the courses that reference an asset",
+          "parameters": [{ "name": "_id", "in": "path", "description": "The asset _id", "required": true }],
+          "responses": { "200": { "description": "Array of { _id, title } for each course referencing the asset" } }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
### New
- Adds `GET /api/content/assetusage/:_id`, returning `[{ _id, title }]` for every course that references the given asset (deduped by course). Complements the existing `POST /api/content/assetusage` (which returns counts) — the asset sheet's "Used in N courses" list needs the actual course titles + ids to link to.
- Reuses the `_assetIds` index and the same course-title resolution as the asset delete-guard (`enforceAssetNotInUse`).

### Testing
- GET `/api/content/assetusage/<assetId>` → array of `{ _id, title }` for the courses using that asset; empty array when unused.