### PR TITLE
New: Enable access control (fixes #117)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -41,6 +41,12 @@ class ContentModule extends AbstractApiModule {
 
     await authored.registerModule(this)
     await tags.registerModule(this)
+    // opt into the generic _access model: public access (base) plus per-user sharing.
+    // Ownership (createdBy) comes from authored; group sharing from usergroups. See
+    // adapt-authoring-api#98.
+    await this.enableAccessControl()
+    const users = await this.app.waitForModule('users')
+    await users.registerUserModule(this)
     /**
      * we have to extend config specifically here because it doesn't use the default content schema
      */
@@ -772,17 +778,21 @@ class ContentModule extends AbstractApiModule {
       const course = await this.findOne(
         { _type: 'course', _courseId },
         { validate: false },
-        { projection: { updatedAt: 1, _type: 1, createdBy: 1, _isShared: 1, _shareWithUsers: 1, userGroups: 1 } }
+        { projection: { updatedAt: 1, _type: 1, createdBy: 1, _access: 1, _isShared: 1, _shareWithUsers: 1, userGroups: 1 } }
       )
       if (!course) {
         throw this.app.errors.NOT_FOUND.setData({ type: 'content', id: _courseId })
       }
-      // this custom handler bypasses the standard per-item access check, so apply
-      // it here: the tree is readable only if the user can access the course
-      // (owner / _isShared / _shareWithUsers / shared group). 404 (not 403) so we
-      // don't leak the course's existence. Supers are exempt.
-      if (!req.auth.isSuper && this.accessCheckHook.hasObservers && !(await this.accessCheckHook.invoke(req, course)).every(Boolean)) {
-        throw this.app.errors.NOT_FOUND.setData({ type: 'content', id: _courseId })
+      // this custom handler bypasses the standard per-item access check, so apply it
+      // here via the shared additive check (grants on any _access dimension: public /
+      // owner / users / groups). 404 (not 403) so we don't leak the course's
+      // existence. Supers are exempt.
+      if (!req.auth.isSuper) {
+        try {
+          await this.checkAccess(req, course)
+        } catch (e) {
+          throw this.app.errors.NOT_FOUND.setData({ type: 'content', id: _courseId })
+        }
       }
       const treeFields = [
         '_id',

--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -39,14 +39,11 @@ class ContentModule extends AbstractApiModule {
     /** @ignore */ this.tags = tags
     /** @ignore */ this._schemaCache = new Map()
 
-    await authored.registerModule(this)
+    // ownership is course-level: the generic createdBy grant is applied by the content
+    // access resolver (adaptframework), not per content item — so opt out of authored's
+    // per-item ownership grant here.
+    await authored.registerModule(this, { accessCheck: false })
     await tags.registerModule(this)
-    // opt into the generic _access model: public access (base) plus per-user sharing.
-    // Ownership (createdBy) comes from authored; group sharing from usergroups. See
-    // adapt-authoring-api#98.
-    await this.enableAccessControl()
-    const users = await this.app.waitForModule('users')
-    await users.registerUserModule(this)
     /**
      * we have to extend config specifically here because it doesn't use the default content schema
      */
@@ -55,10 +52,12 @@ class ContentModule extends AbstractApiModule {
       this.registerConfigSchemas()
       jsonschema.extendSchema('content', 'contentassets')
       jsonschema.extendSchema('content', 'contentsummary')
+      this.registerAccessSchemas(jsonschema)
     })
     await this.registerConfigSchemas()
     jsonschema.extendSchema('content', 'contentassets')
     jsonschema.extendSchema('content', 'contentsummary')
+    this.registerAccessSchemas(jsonschema)
 
     // bump course.updatedAt so tree endpoint If-Modified-Since invalidates
     this.postInsertHook.tap(this.touchCourse.bind(this))
@@ -83,6 +82,19 @@ class ContentModule extends AbstractApiModule {
       partialFilterExpression: { _friendlyId: { $type: 'string', $gt: '' } }
     })
     await mongodb.setIndex(this.counterCollectionName, { _type: 1, _courseId: 1 }, { unique: true })
+  }
+
+  /**
+   * Extends the course schema with the generic `_access` grant fields (public + per-user
+   * sharing) so course sharing can be stored and edited. Scoped to the `course` schema — NOT
+   * the base `content` schema — so nested content items carry no `_access` of their own and
+   * can't self-grant; content access is resolved to the course centrally (adaptframework).
+   * Group sharing (`_access.groups`) is added to the course schema by the usergroups module.
+   * @param {Object} jsonschema The jsonschema module
+   */
+  registerAccessSchemas (jsonschema) {
+    jsonschema.extendSchema('course', 'access')
+    jsonschema.extendSchema('course', 'users')
   }
 
   /**

--- a/tests/ContentModule.spec.js
+++ b/tests/ContentModule.spec.js
@@ -679,12 +679,12 @@ describe('ContentModule', () => {
       assert.equal(next.mock.calls[0].arguments[0].message, 'db error')
     })
 
-    it('should run the per-item access check for non-super users and return the tree when allowed', async () => {
+    it('should run the additive access check for non-super users and return the tree when allowed', async () => {
       const lastModified = new Date('2025-01-15T00:00:00Z')
       const course = { _id: COURSE_ID, _type: 'course', updatedAt: lastModified }
-      const accessCheckHook = { hasObservers: true, invoke: mock.fn(async () => [true]) }
+      const checkAccess = mock.fn(async () => course)
       const inst = createInstance({
-        accessCheckHook,
+        checkAccess,
         findOne: mock.fn(async () => course),
         find: mock.fn(async () => [{ _id: COURSE_ID, _type: 'course', _courseId: COURSE_ID }])
       })
@@ -693,16 +693,16 @@ describe('ContentModule', () => {
       const next = mock.fn()
       await ContentModule.prototype.handleTree.call(inst, req, res, next)
 
-      assert.equal(accessCheckHook.invoke.mock.callCount(), 1, 'access check invoked')
-      assert.deepEqual(accessCheckHook.invoke.mock.calls[0].arguments, [req, course], 'check receives req + the course')
+      assert.equal(checkAccess.mock.callCount(), 1, 'access check invoked')
+      assert.deepEqual(checkAccess.mock.calls[0].arguments, [req, course], 'check receives req + the course')
       assert.equal(inst.find.mock.callCount(), 1)
       assert.equal(next.mock.callCount(), 0)
     })
 
     it('should 404 (not leak existence) when the access check denies the course', async () => {
-      const accessCheckHook = { hasObservers: true, invoke: mock.fn(async () => [false]) }
+      const checkAccess = mock.fn(async () => { throw new Error('UNAUTHORISED') })
       const inst = createInstance({
-        accessCheckHook,
+        checkAccess,
         findOne: mock.fn(async () => ({ _id: COURSE_ID, _type: 'course', updatedAt: new Date() })),
         app: { errors: { NOT_FOUND: { setData: () => new Error('NOT_FOUND') } } }
       })
@@ -716,9 +716,9 @@ describe('ContentModule', () => {
     })
 
     it('should skip the access check for super users', async () => {
-      const accessCheckHook = { hasObservers: true, invoke: mock.fn(async () => [false]) }
+      const checkAccess = mock.fn(async () => { throw new Error('should not run for super') })
       const inst = createInstance({
-        accessCheckHook,
+        checkAccess,
         findOne: mock.fn(async () => ({ _id: COURSE_ID, _type: 'course', updatedAt: new Date('2025-01-15T00:00:00Z') })),
         find: mock.fn(async () => [])
       })
@@ -727,7 +727,7 @@ describe('ContentModule', () => {
       const next = mock.fn()
       await ContentModule.prototype.handleTree.call(inst, req, res, next)
 
-      assert.equal(accessCheckHook.invoke.mock.callCount(), 0, 'super bypasses the access check')
+      assert.equal(checkAccess.mock.callCount(), 0, 'super bypasses the access check')
       assert.equal(next.mock.callCount(), 0)
     })
   })


### PR DESCRIPTION
### Fixes #117

### New
- Opt content into the generic `_access` model. Sharing is a **course-level** concept, so the `_access` grant fields (`public` + per-user `users`; `groups` added by usergroups) are added to the **`course` schema only** — nested content items carry no `_access` of their own.

### Update
- Content access enforcement is **course-resolved**, not per-item: a page/block is judged by resolving to its parent course and applying the course's `_access` (handled centrally by adaptframework's resolver, #194). Content therefore does **not** tap the flat per-item grants — nested items must not self-grant on a default-`public` `_access`. It registers with authored as `{ accessCheck: false }` (ownership is course-level too).
- `handleTree` now enforces access via the shared additive `checkAccess` on the course (replacing the old manual `.every(Boolean)` invoke), wrapped to keep the deliberate 404 and super-exemption. Projects `_access`.

### Testing
- `handleTree` access specs updated to the `checkAccess` path (allowed / 404-on-deny / super-skips); full suite passes (223 tests, run with `--experimental-test-module-mocks`); `npx standard` clean.

### Notes
- Part of the `_access` rollout (api #98). Enforcement + the legacy->`_access` course backfill live in adaptframework #194. Lands in the coordinated umbrella release with usergroups #14, assets #66 and adaptframework #194.
