### PR TITLE
Fix: guard _friendlyId migration against typeless docs (fixes #143)

### DIFF
--- a/lib/utils/formatFriendlyId.js
+++ b/lib/utils/formatFriendlyId.js
@@ -6,6 +6,7 @@
  * @return {String}
  */
 export default function formatFriendlyId (_type, count, _language) {
+  if (!_type) throw new Error('formatFriendlyId requires a _type')
   if (_type === 'course') return `course-${count}${_language ? `-${_language}` : ''}`
   if (_type === 'config') return 'config'
   return `${_type[0]}-${count}`

--- a/migrations/3.0.0.js
+++ b/migrations/3.0.0.js
@@ -45,7 +45,13 @@ async function backfillFriendlyIds (db, log) {
     groups.get(key).docs.push(doc)
   }
 
+  let skipped = 0
   for (const { courseId, type, docs } of groups.values()) {
+    if (!type) {
+      skipped += docs.length
+      log('warn', 'migrations', `Skipping ${docs.length} orphaned content document(s) with no _type: ${docs.map(d => d._id).join(', ')}`)
+      continue
+    }
     if (type === 'config') {
       for (const doc of docs) {
         await content.updateOne({ _id: doc._id }, { $set: { _friendlyId: formatFriendlyId('config') } })
@@ -72,7 +78,7 @@ async function backfillFriendlyIds (db, log) {
       nextSeq++
     }
   }
-  log('info', 'migrations', `Backfilled _friendlyId for ${missing.length} document(s)`)
+  log('info', 'migrations', `Backfilled _friendlyId for ${missing.length - skipped} document(s)${skipped ? ` (${skipped} orphaned document(s) skipped)` : ''}`)
 }
 
 async function backfillAssetIds (db, log) {

--- a/tests/utils-formatFriendlyId.spec.js
+++ b/tests/utils-formatFriendlyId.spec.js
@@ -23,6 +23,14 @@ describe('formatFriendlyId', () => {
     })
   })
 
+  describe('missing type', () => {
+    for (const _type of [undefined, null, '']) {
+      it(`throws for _type ${JSON.stringify(_type)}`, () => {
+        assert.throws(() => formatFriendlyId(_type, 1), /requires a _type/)
+      })
+    }
+  })
+
   describe('other types', () => {
     const cases = [
       { _type: 'page', count: 1, expected: 'p-1' },


### PR DESCRIPTION
### Fixes #143

### Fix

- `migrations/3.0.0.js` (`backfillFriendlyIds`): the `_friendlyId` backfill crashed the entire migration run — and therefore app startup — when the `content` collection held a document with no `_type` (`formatFriendlyId` evaluated `undefined[0]`, throwing `Cannot read properties of undefined (reading '0')`). It now skips such orphaned documents, logs a `warn` listing their `_id`s, and continues. The completion log reports how many were skipped.
- `lib/utils/formatFriendlyId.js`: throws a descriptive error when `_type` is missing, instead of the cryptic property-access error.

### Testing

- Added unit tests: `formatFriendlyId` throws for `undefined`/`null`/`''` types.
- `node --test 'tests/**/*.spec.js'` → 226 pass, 0 fail.
- `standard` lint clean.
