### PR TITLE
Update: expose _assetIds in content tree (fixes #142)

### DIFF
--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -96,11 +96,12 @@ Projected fields (`treeFields` in `handleTree`):
 ```
 _id, _parentId, _courseId, _type, _sortOrder, title, displayTitle,
 _friendlyId, _component, _layout, _menu, _theme, _enabledPlugins,
-_colorLabel, _language, heroImage, updatedAt
+_colorLabel, _language, heroImage, _summary, _assetIds, updatedAt
 ```
 
 Each returned item also carries a `_children` array of child `_id`s, computed
-from the in-memory tree.
+from the in-memory tree. `_assetIds` (see below) is included so tree consumers
+can tell which nodes reference a given asset without fetching full documents.
 
 Caching is via a **weak ETag**, not `Last-Modified` (despite the `routes.json`
 OpenAPI `meta` still describing `If-Modified-Since`). `treeEtag`

--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -824,6 +824,7 @@ class ContentModule extends AbstractApiModule {
         '_language',
         'heroImage',
         '_summary',
+        '_assetIds',
         'updatedAt'
       ]
       // ETag (not Last-Modified): folds the projected field list into the


### PR DESCRIPTION
### Fixes #142

### Update
* Add `_assetIds` to the `handleTree` projection so tree consumers can determine which nodes reference a given asset without fetching full documents. `_assetIds` is already stored and indexed, and the endpoint's ETag folds the projected field list into its validator, so adding the field busts the cache correctly.

### Docs
* Update the tree-endpoint field list in `content-model.md` (also fills in the previously-missing `_summary`).
