### PR TITLE
Fix: set updatedBy server-side in insertRecursive (fixes #147)

### DIFF
--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -518,7 +518,8 @@ class ContentModule extends AbstractApiModule {
     try {
       // figure out which children need creating
       if (rootId === undefined) { // new course
-        parent = await this.insert({ _type: 'course', createdBy, ...req.apiData.data }, { schemaName: 'course' })
+        // server owns the authored tracking fields: spread client data first so createdBy/updatedBy can't be overridden (or sent empty) by the request
+        parent = await this.insert({ ...req.apiData.data, _type: 'course', createdBy, updatedBy: createdBy }, { schemaName: 'course' })
         newItems.push(parent)
         childTypes.splice(0, 1, 'config')
         parentIsNew = true
@@ -530,7 +531,7 @@ class ContentModule extends AbstractApiModule {
           : childTypes = childTypes.slice(childTypes.indexOf(parent._type) + 1)
       }
       for (const _type of childTypes) {
-        const data = Object.assign({ _type, createdBy }, defaultData[_type])
+        const data = Object.assign({ _type, createdBy, updatedBy: createdBy }, defaultData[_type])
         if (parent) {
           Object.assign(data, {
             _parentId: parent._id.toString(),

--- a/tests/ContentModule.spec.js
+++ b/tests/ContentModule.spec.js
@@ -141,9 +141,9 @@ describe('ContentModule', () => {
   })
 
   describe('insertRecursive', () => {
-    function createReq ({ rootId, body } = {}) {
+    function createReq ({ rootId, body, data = {} } = {}) {
       return {
-        apiData: { query: { rootId }, data: {} },
+        apiData: { query: { rootId }, data },
         auth: { user: { _id: 'user1' } },
         body,
         translate: key => key
@@ -178,6 +178,23 @@ describe('ContentModule', () => {
       for (const d of needSortOrder) {
         assert.equal(typeof d._sortOrder, 'number', `${d._type} inserted without numeric _sortOrder`)
       }
+    })
+
+    it('should set updatedBy on every document created for a new course', async () => {
+      const { instance, insertCalls } = createRecursiveInstance()
+      await ContentModule.prototype.insertRecursive.call(instance, createReq())
+      for (const d of insertCalls) {
+        assert.equal(d.updatedBy, 'user1', `${d._type} inserted without updatedBy`)
+      }
+    })
+
+    it('should override a client-supplied updatedBy/createdBy on the new course with the acting user', async () => {
+      const { instance, insertCalls } = createRecursiveInstance()
+      await ContentModule.prototype.insertRecursive.call(instance, createReq({ data: { updatedBy: '', createdBy: 'someone-else', title: 'My course' } }))
+      const course = insertCalls.find(d => d._type === 'course')
+      assert.equal(course.createdBy, 'user1')
+      assert.equal(course.updatedBy, 'user1')
+      assert.equal(course.title, 'My course')
     })
   })
 


### PR DESCRIPTION
### Fixes #147

### Fix
- `insertRecursive` now sets `updatedBy` on every document it creates (course + children), to the acting user — matching the generic create path (`updateAuthor`).
- The new-course insert spreads the request data first, so the server-owned `_type`/`createdBy`/`updatedBy` can no longer be overridden (or blanked) by client-supplied values.

This fixes `Incorrect data provided: /updatedBy must pass "isObjectId" keyword validation` when a client submits course data that includes an empty `updatedBy`.

### Testing
- Added unit tests: `updatedBy` is set on every created document, and a client-supplied `createdBy`/`updatedBy` on the course is overridden by the acting user.
- Full module test suite passes (228 tests).
