### PR TITLE
Update: summarise body + instruction for all content types (fixes #149)

### DIFF
--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -212,6 +212,38 @@ Two consumers:
   scopes the counts; assets with no usage are omitted. Counting distinct
   `_courseId` (`$addToSet`) means many references within one course count once.
 
+## `_summary`
+
+Each content document carries `_summary`: a display-only array of "cells" that the
+authoring UI renders as a compact second line under the item's title on the course
+structure page. It is computed by `computeSummary` → `extractSummary`
+(`lib/utils/extractSummary.js`) on insert and **recomputed on every update** from the
+full merged document, and stored on the doc (it is never queried, so a plain value
+comparison skips no-op writes). Every type gets one except `config`, which has no
+display card.
+
+The fields summarised are resolved by `resolveSummaryFields`
+(`lib/utils/resolveSummaryFields.js`) with this precedence:
+
+1. **`summaryFields` config override** — an optional map of `_component` name →
+   ordered selectors (`lib/ContentModule.js` reads `getConfig('summaryFields')`).
+2. **Schema annotations** — fields tagged `_adapt.summary` in the built schema,
+   ordered by the optional `_adapt.summary.order`.
+3. **Default** — `['body', 'instruction']`. Containers carry no summary annotations,
+   so they fall through to this; a component without annotations does too.
+
+Each selector becomes one cell via `reduceToCell`
+(`kind` ∈ `text | asset | collection | boolean | number`), carrying the source
+`field` key (its leaf selector segment) so consumers can style a specific field —
+the UI uses `field === 'instruction'` to label the instruction apart from the body.
+Selectors whose value is missing/empty are dropped, so a doc without `instruction`
+simply shows only its body.
+
+Migration `migrations/3.9.0.js` backfills `_summary` on existing **container**
+documents (the default `body`/`instruction` cells). Existing components keep their
+already-correct stored summary and pick up the instruction default on next edit —
+recomputing them would need the schema module, which migrations run without.
+
 ## `_enabledPlugins`
 
 The course `config` document holds `_enabledPlugins` — the list of content

--- a/lib/ContentModule.js
+++ b/lib/ContentModule.js
@@ -357,13 +357,16 @@ class ContentModule extends AbstractApiModule {
   }
 
   /**
-   * Computes the display-only _summary cell array for a component document. Non-component
-   * types have no summary (their title suffices on the structure page) and return [].
+   * Computes the display-only _summary cell array for a content document. Every type
+   * with body/instruction (or schema-annotated summary fields) gets a summary; the
+   * `config` root has no display card and returns []. A component resolves its cells
+   * from its `_component` schema; containers fall through to the `['body', 'instruction']`
+   * default in resolveSummaryFields.
    * @param {Object} doc Full content document
    * @return {Promise<Array<Object>>} Summary cells for the doc
    */
   async computeSummary (doc) {
-    if (doc._type !== 'component' || !doc._component) return []
+    if (doc._type === 'config') return []
     const schema = await this.getSchema(this.schemaName, doc)
     return extractSummary(schema, doc, doc._component, this.getConfig('summaryFields') ?? {})
   }

--- a/lib/utils/extractSummary.js
+++ b/lib/utils/extractSummary.js
@@ -31,7 +31,9 @@ function buildCell (selector, properties, data) {
   if (inferCellKind(field) === 'collection') return buildCollectionCell(`${selector}[]`, properties, data)
   const value = resolveValue(data, keys)
   if (value === undefined || value === null || value === '') return null
-  return reduceToCell(value, field, { label: labelFor(field, keys) })
+  const cell = reduceToCell(value, field, { label: labelFor(field, keys) })
+  cell.field = keys[keys.length - 1]
+  return cell
 }
 
 function buildCollectionCell (selector, properties, data) {
@@ -54,7 +56,7 @@ function buildCollectionCell (selector, properties, data) {
       })
       .filter(Boolean)
     : []
-  return { kind: 'collection', label: labelFor(arrField, arrKeys), count: arr.length, items }
+  return { kind: 'collection', field: arrKeys[arrKeys.length - 1], label: labelFor(arrField, arrKeys), count: arr.length, items }
 }
 
 function resolveField (properties, keys) {

--- a/lib/utils/resolveSummaryFields.js
+++ b/lib/utils/resolveSummaryFields.js
@@ -1,7 +1,7 @@
 /**
  * Resolves the ordered list of summary field selectors for a content document.
  * Precedence: override config map (by component name) → schema annotations
- * (`_adapt.summary`, ordered by its optional `order`) → `['body']`.
+ * (`_adapt.summary`, ordered by its optional `order`) → `['body', 'instruction']`.
  * @param {Object} schema Built Schema instance (has a walk method)
  * @param {Object} data Content document
  * @param {String} componentName The doc's _component (may be undefined)
@@ -27,7 +27,7 @@ export default function resolveSummaryFields (schema, data, componentName, summa
         return selectors
       }, [])
   }
-  return ['body']
+  return ['body', 'instruction']
 }
 
 /**

--- a/migrations/3.9.0.js
+++ b/migrations/3.9.0.js
@@ -1,0 +1,52 @@
+import stripText from '../lib/utils/stripText.js'
+
+export default function (migration) {
+  migration.describe('Backfill _summary (body + instruction) on existing container content documents')
+  migration.runCommand(backfillContainerSummaries)
+}
+
+// Containers (page/article/block/menu/course) gained a display summary — the same
+// `['body', 'instruction']` default the live write path now applies to every type.
+// Migrations run against a bare mongo connection with no schema module, but a
+// container carries no schema summary annotations, so a direct body+instruction
+// build matches the pipeline output exactly. Components are left untouched: their
+// stored _summary is already correct for their schema and picks up the new
+// instruction default on next edit (recomputing them would need schemas we lack here).
+async function backfillContainerSummaries (db, log) {
+  const content = db.collection('content')
+  const docs = await content
+    .find(
+      {
+        _type: { $nin: ['component', 'config'] },
+        $or: [
+          { body: { $type: 'string', $ne: '' } },
+          { instruction: { $type: 'string', $ne: '' } }
+        ]
+      },
+      { projection: { _id: 1, body: 1, instruction: 1 } }
+    )
+    .toArray()
+  if (!docs.length) {
+    log('info', 'migrations', 'No container documents with body/instruction found, skipping')
+    return
+  }
+
+  const ops = docs
+    .map(doc => ({ _id: doc._id, cells: buildCells(doc) }))
+    .filter(({ cells }) => cells.length)
+    .map(({ _id, cells }) => ({ updateOne: { filter: { _id }, update: { $set: { _summary: cells } } } }))
+
+  for (let i = 0; i < ops.length; i += 500) {
+    await content.bulkWrite(ops.slice(i, i + 500), { ordered: false })
+  }
+  log('info', 'migrations', `backfilled _summary on ${ops.length} container document(s)`)
+}
+
+function buildCells (doc) {
+  return [['body', 'Body'], ['instruction', 'Instruction']]
+    .map(([field, label]) => {
+      const text = stripText(doc[field])
+      return text ? { kind: 'text', field, label, text } : null
+    })
+    .filter(Boolean)
+}

--- a/tests/utils-extractSummary.spec.js
+++ b/tests/utils-extractSummary.spec.js
@@ -29,7 +29,18 @@ describe('extractSummary()', () => {
     const schema = mockSchema(TEXT)
     assert.deepEqual(
       extractSummary(schema, { body: '<p>Hello</p>' }, 'text', {}),
-      [{ kind: 'text', label: 'body', text: 'Hello' }]
+      [{ kind: 'text', label: 'body', text: 'Hello', field: 'body' }]
+    )
+  })
+
+  it('tags each cell with its source field and defaults to body + instruction', () => {
+    const schema = mockSchema({ body: { type: 'string' }, instruction: { type: 'string' } })
+    assert.deepEqual(
+      extractSummary(schema, { body: 'b', instruction: 'do it' }, undefined, {}),
+      [
+        { kind: 'text', label: 'body', text: 'b', field: 'body' },
+        { kind: 'text', label: 'instruction', text: 'do it', field: 'instruction' }
+      ]
     )
   })
 
@@ -43,7 +54,7 @@ describe('extractSummary()', () => {
     const schema = mockSchema({ _graphic: { properties: { src: { _backboneForms: 'Asset' } } } })
     assert.deepEqual(
       extractSummary(schema, { _graphic: { src: 'img1' } }, 'graphic', { graphic: ['_graphic.src'] }),
-      [{ kind: 'asset', label: 'src', assetId: 'img1' }]
+      [{ kind: 'asset', label: 'src', assetId: 'img1', field: 'src' }]
     )
   })
 

--- a/tests/utils-resolveSummaryFields.spec.js
+++ b/tests/utils-resolveSummaryFields.spec.js
@@ -31,7 +31,7 @@ describe('resolveSummaryFields()', () => {
 
   it('ignores an empty override array and falls through', () => {
     const schema = mockSchema({ body: { type: 'string' } })
-    assert.deepEqual(resolveSummaryFields(schema, { body: 'x' }, 'mcq', { mcq: [] }), ['body'])
+    assert.deepEqual(resolveSummaryFields(schema, { body: 'x' }, 'mcq', { mcq: [] }), ['body', 'instruction'])
   })
 
   it('discovers annotated fields and converts paths to selectors', () => {
@@ -53,8 +53,8 @@ describe('resolveSummaryFields()', () => {
     assert.deepEqual(resolveSummaryFields(schema, data, 'custom', {}), ['_items[].text', 'body'])
   })
 
-  it('falls back to body when no override and no annotations', () => {
+  it('falls back to body + instruction when no override and no annotations', () => {
     const schema = mockSchema({ body: { type: 'string' } })
-    assert.deepEqual(resolveSummaryFields(schema, { body: 'x' }, 'unknown', {}), ['body'])
+    assert.deepEqual(resolveSummaryFields(schema, { body: 'x' }, 'unknown', {}), ['body', 'instruction'])
   })
 })


### PR DESCRIPTION
### Fixes #149

### Update
* `computeSummary` now runs for every content type except `config` (was component-only); containers resolve their cells from the shared summary pipeline.
* Default summary selectors are now `['body', 'instruction']` (was `['body']`). Empty/undefined fields are dropped, so only defined fields render.
* Each summary cell carries its source `field` key, so consumers can style a specific field (e.g. label the instruction apart from the body).
* Migration `3.9.0` backfills `_summary` on existing container documents — a replica-set-safe `find` + `bulkWrite`, no schema dependency. Existing components keep their stored summary and pick up the instruction default on next edit.
* New `_summary` section in `content-model.md` documenting the mechanism, precedence, cell shape, and migration.

### Testing
1. `node --experimental-test-module-mocks --test 'tests/**/*.spec.js'` — 227 pass.
2. On boot, the migration backfilled `_summary` on existing container documents; container docs now expose `body`/`instruction` cells in `GET /content/tree/:_id`.
